### PR TITLE
Align Turtle files with SPARQL files

### DIFF
--- a/test-suite/test-cases/rdfa1.0/html4/0040.ttl
+++ b/test-suite/test-cases/rdfa1.0/html4/0040.ttl
@@ -1,0 +1,1 @@
+<http://sw-app.org/img/mic_2006_03.jpg>  <http://www.w3.org/1999/xhtml/vocab#alternate> <http://sw-app.org/img/mic_2007_01.jpg> .

--- a/test-suite/test-cases/rdfa1.0/html4/0058.ttl
+++ b/test-suite/test-cases/rdfa1.0/html4/0058.ttl
@@ -1,4 +1,10 @@
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 
-<http://www.example.org/#ben> foaf:knows [ foaf:name [ a foaf:Person],  [ a foaf:Person]] .
+<http://www.example.org/#ben> foaf:knows [
+      a foaf:Person;
+      foaf:name "Mark Birbeck"
+   ], [
+      a foaf:Person;
+      foaf:name "Ivan Herman"
+   ] .

--- a/test-suite/test-cases/rdfa1.0/html4/0078.ttl
+++ b/test-suite/test-cases/rdfa1.0/html4/0078.ttl
@@ -2,7 +2,8 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<http://www.example.org/#somebody> foaf:knows [
-     foaf:mailbox <mailto:ivan@w3.org>;
-     foaf:name "Ivan Herman",  [ a foaf:Person]
-   ] .
+<http://www.example.org/#somebody> foaf:knows
+   [ foaf:name "Ivan Herman";
+     foaf:mailbox <mailto:ivan@w3.org> ],
+  [ a foaf:Person;
+    foaf:name "Mark Birbeck" ] .

--- a/test-suite/test-cases/rdfa1.0/html4/0081.ttl
+++ b/test-suite/test-cases/rdfa1.0/html4/0081.ttl
@@ -5,5 +5,10 @@
  [
      foaf:knows <http://www.example.org/#somebody>;
      foaf:mailbox <mailto:ivan@w3.org>;
-     foaf:name "Ivan Herman",  [ a foaf:Person]
+     foaf:name "Ivan Herman"
+ ] .
+ [
+     a foaf:Person;
+     foaf:knows <http://www.example.org/#somebody>;
+     foaf:name "Mark Birbeck"
  ] .

--- a/test-suite/test-cases/rdfa1.0/html4/0082.ttl
+++ b/test-suite/test-cases/rdfa1.0/html4/0082.ttl
@@ -5,5 +5,9 @@
 <http://www.example.org/#somebody> foaf:knows [
      foaf:knows <http://www.example.org/#somebody>;
      foaf:mailbox <mailto:ivan@w3.org>;
-     foaf:name "Ivan Herman",  [ a foaf:Person]
+     foaf:name "Ivan Herman"
+   ], [
+     a foaf:Person;
+     foaf:knows <http://www.example.org/#somebody>;
+     foaf:name "Mark Birbeck"
    ] .

--- a/test-suite/test-cases/rdfa1.0/html4/0090.ttl
+++ b/test-suite/test-cases/rdfa1.0/html4/0090.ttl
@@ -1,3 +1,3 @@
 @prefix xhv: <http://www.w3.org/1999/xhtml/vocab#> .
 
-<http://rdfa.info/test-suite/test-cases/rdfa1.0/html4/0090.html> xhv:license <http://creativecommons.org/licenses/by-nc-sa/2.0/> .
+<http://example.org/example.png> xhv:license <http://creativecommons.org/licenses/by-nc-sa/2.0/> .

--- a/test-suite/test-cases/rdfa1.0/html4/0210.ttl
+++ b/test-suite/test-cases/rdfa1.0/html4/0210.ttl
@@ -1,4 +1,4 @@
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<http://example.org/#me> foaf:name "Ivan Herman" .
+<http://example.org/#me> <http://www.example.com/wrong/foaf/uri/name> "Ivan Herman" .

--- a/test-suite/test-cases/rdfa1.0/html4/0212.ttl
+++ b/test-suite/test-cases/rdfa1.0/html4/0212.ttl
@@ -1,4 +1,5 @@
 @prefix dc11: <http://purl.org/dc/elements/1.1/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<http://www.example.org/> dc11:title "E = mc2: The Most Urgent Problem of Our Time" .
+<http://www.example.org/> dc11:title "E = mc<sup xmlns=\"http://www.w3.org/1999/xhtml\" xmlns:dc=\"http://purl.org/dc/elements/1.1/\">2</sup>: The Most Urgent Problem of Our Time"^^xsd:XMLLiteral .

--- a/test-suite/test-cases/rdfa1.0/svg/0311.ttl
+++ b/test-suite/test-cases/rdfa1.0/svg/0311.ttl
@@ -1,0 +1,1 @@
+<http://rdfa.info/test-suite/test-cases/rdfa1.1/xhtml1/0063.xhtml> <http://www.w3.org/1999/xhtml/vocab#prev> <http://rdfa.info/test-suite/test-cases/rdfa1.1/xhtml1/0062.xhtml> .

--- a/test-suite/test-cases/rdfa1.0/xhtml1/0211.ttl
+++ b/test-suite/test-cases/rdfa1.0/xhtml1/0211.ttl
@@ -1,2 +1,2 @@
 
-<http://example.org/> <http://www.w3.org/ns/rdfa#usesVocabulary> <http://xmlns.com/foaf/0.1/> .
+<http://example.org/#me> <http://xmlns.com/foaf/0.1/name> "Ivan Herman" .

--- a/test-suite/test-cases/rdfa1.0/xhtml1/0212.ttl
+++ b/test-suite/test-cases/rdfa1.0/xhtml1/0212.ttl
@@ -1,3 +1,3 @@
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 
-<http://www.example.org/> dc:title "E = mc<sup>2</sup>: The Most Urgent Problem of Our Time<sup xmlns=\"http://www.w3.org/1999/xhtml\" xmlns:dc=\"http://purl.org/dc/elements/1.1/\">2</sup>"^^<http://www.w3.org/1999/02/22-rdf-syntax-ns#XMLLiteral> .
+<http://www.example.org/> dc:title "E = mc<sup xmlns=\"http://www.w3.org/1999/xhtml\" xmlns:dc=\"http://purl.org/dc/elements/1.1/\">2</sup>: The Most Urgent Problem of Our Time"^^<http://www.w3.org/1999/02/22-rdf-syntax-ns#XMLLiteral> .

--- a/test-suite/test-cases/rdfa1.0/xml/0013.ttl
+++ b/test-suite/test-cases/rdfa1.0/xml/0013.ttl
@@ -1,4 +1,4 @@
 @prefix ex: <http://example.org/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-ex:node ex:property "chat" .
+ex:node ex:property "chat"@fr .

--- a/test-suite/test-cases/rdfa1.0/xml/0046.ttl
+++ b/test-suite/test-cases/rdfa1.0/xml/0046.ttl
@@ -2,7 +2,9 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<http://rdfa.info/test-suite/test-cases/rdfa1.0/xml/0046.xml> foaf:maker [
-     a foaf:Document;
-     foaf:name "John Doe"
-   ] .
+[
+   a foaf:Document;
+   foaf:maker [
+      foaf:name "John Doe"
+   ]
+] .

--- a/test-suite/test-cases/rdfa1.0/xml/0047.ttl
+++ b/test-suite/test-cases/rdfa1.0/xml/0047.ttl
@@ -2,7 +2,9 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<http://rdfa.info/test-suite/test-cases/rdfa1.0/xml/0047.xml> foaf:maker <http://www.example.org/#me> .
+[
+   a foaf:Document;
+   foaf:maker <http://www.example.org/#me>
+] .
 
-<http://www.example.org/#me> a foaf:Document;
-   foaf:name "John Doe" .
+<http://www.example.org/#me> foaf:name "John Doe" .

--- a/test-suite/test-cases/rdfa1.0/xml/0058.ttl
+++ b/test-suite/test-cases/rdfa1.0/xml/0058.ttl
@@ -1,4 +1,10 @@
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 
-<http://www.example.org/#ben> foaf:knows [ foaf:name [ a foaf:Person],  [ a foaf:Person]] .
+<http://www.example.org/#ben> foaf:knows [
+   a foaf:Person;
+   foaf:name "Mark Birbeck"
+], [
+   a foaf:Person;
+   foaf:name "Ivan Herman"
+] .

--- a/test-suite/test-cases/rdfa1.0/xml/0078.ttl
+++ b/test-suite/test-cases/rdfa1.0/xml/0078.ttl
@@ -3,6 +3,9 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <http://www.example.org/#somebody> foaf:knows [
-     foaf:mailbox <mailto:ivan@w3.org>;
-     foaf:name "Ivan Herman",  [ a foaf:Person]
+      foaf:mailbox <mailto:ivan@w3.org>;
+      foaf:name "Ivan Herman"
+   ], [
+      a foaf:Person;
+      foaf:name "Mark Birbeck"
    ] .

--- a/test-suite/test-cases/rdfa1.0/xml/0081.ttl
+++ b/test-suite/test-cases/rdfa1.0/xml/0081.ttl
@@ -5,5 +5,10 @@
  [
      foaf:knows <http://www.example.org/#somebody>;
      foaf:mailbox <mailto:ivan@w3.org>;
-     foaf:name "Ivan Herman",  [ a foaf:Person]
+     foaf:name "Ivan Herman"
+ ] .
+ [
+     a foaf:Person;
+     foaf:knows <http://www.example.org/#somebody>;
+     foaf:name "Mark Birbeck"
  ] .

--- a/test-suite/test-cases/rdfa1.0/xml/0082.ttl
+++ b/test-suite/test-cases/rdfa1.0/xml/0082.ttl
@@ -5,5 +5,9 @@
 <http://www.example.org/#somebody> foaf:knows [
      foaf:knows <http://www.example.org/#somebody>;
      foaf:mailbox <mailto:ivan@w3.org>;
-     foaf:name "Ivan Herman",  [ a foaf:Person]
+     foaf:name "Ivan Herman"
+   ], [
+     a foaf:Person;
+     foaf:knows <http://www.example.org/#somebody>;
+     foaf:name "Mark Birbeck"
    ] .

--- a/test-suite/test-cases/rdfa1.0/xml/0113.ttl
+++ b/test-suite/test-cases/rdfa1.0/xml/0113.ttl
@@ -2,7 +2,4 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <http://rdfa.info/test-suite/test-cases/rdfa1.0/xml/0113.xml#a> dc11:title "" .
-
-<http://rdfa.info/test-suite/test-cases/rdfa1.0/xml/0113.xml#b> dc11:title """
-  
-""" .
+<http://rdfa.info/test-suite/test-cases/rdfa1.0/xml/0113.xml#b> dc11:title "" .

--- a/test-suite/test-cases/rdfa1.0/xml/0121.ttl
+++ b/test-suite/test-cases/rdfa1.0/xml/0121.ttl
@@ -2,5 +2,4 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <http://example.org/> dc11:title "Test Case 0121" .
-
-<http://rdfa.info/test-suite/test-cases/rdfa1.0/xml/0121.xml> dc11:contributor "Shane McCarron" .
+<http://example.org/> dc11:contributor "Shane McCarron" .

--- a/test-suite/test-cases/rdfa1.0/xml/0202.ttl
+++ b/test-suite/test-cases/rdfa1.0/xml/0202.ttl
@@ -1,4 +1,4 @@
 @prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<http://rdfa.info/test-suite/test-cases/rdfa1.0/xml/0202.xml> dcterms:description "A yellow rectangle with sharp corners." .
+<http://example.com/> dcterms:description "A yellow rectangle with sharp corners." .

--- a/test-suite/test-cases/rdfa1.0/xml/0203.ttl
+++ b/test-suite/test-cases/rdfa1.0/xml/0203.ttl
@@ -1,4 +1,4 @@
 @prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<http://rdfa.info/test-suite/test-cases/rdfa1.0/xml/0203.xml> dcterms:description "A yellow rectangle with sharp corners." .
+<http://example.com/> dcterms:description "A yellow rectangle with sharp corners." .

--- a/test-suite/test-cases/rdfa1.0/xml/0209.ttl
+++ b/test-suite/test-cases/rdfa1.0/xml/0209.ttl
@@ -1,4 +1,3 @@
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<http://rdfa.info/test-suite/test-cases/rdfa1.0/xml/0209.xml#me> foaf:name "Ivan Herman" .
+<http://example.org/#me> foaf:name "Ivan Herman" .

--- a/test-suite/test-cases/rdfa1.0/xml/0210.ttl
+++ b/test-suite/test-cases/rdfa1.0/xml/0210.ttl
@@ -1,4 +1,1 @@
-@prefix foaf: <http://xmlns.com/foaf/0.1/> .
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-
-<http://rdfa.info/test-suite/test-cases/rdfa1.0/xml/0210.xml#me> foaf:name "Ivan Herman" .
+<http://example.org/#me> <http://www.example.com/wrong/foaf/uri/name> "Ivan Herman" .

--- a/test-suite/test-cases/rdfa1.0/xml/0211.ttl
+++ b/test-suite/test-cases/rdfa1.0/xml/0211.ttl
@@ -1,7 +1,3 @@
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
-@prefix rdfa: <http://www.w3.org/ns/rdfa#> .
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-
-<http://rdfa.info/test-suite/test-cases/rdfa1.0/xml/0211.xml> rdfa:usesVocabulary foaf: .
 
 <http://rdfa.info/test-suite/test-cases/rdfa1.0/xml/0211.xml#me> foaf:name "Ivan Herman" .

--- a/test-suite/test-cases/rdfa1.0/xml/0212.ttl
+++ b/test-suite/test-cases/rdfa1.0/xml/0212.ttl
@@ -1,4 +1,5 @@
 @prefix dc11: <http://purl.org/dc/elements/1.1/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<http://www.example.org/> dc11:title "E = mc2: The Most Urgent Problem of Our Time" .
+<http://www.example.org/> dc11:title "E = mc<sup xmlns=\"http://www.w3.org/1999/xhtml\" xmlns:dc=\"http://purl.org/dc/elements/1.1/\">2</sup>: The Most Urgent Problem of Our Time"^^rdf:XMLLiteral .

--- a/test-suite/test-cases/rdfa1.1-lite/html5/0281.ttl
+++ b/test-suite/test-cases/rdfa1.1-lite/html5/0281.ttl
@@ -1,4 +1,4 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<http://rdfa.info/test-suite/test-cases/rdfa1.1-lite/html5/0281.html> rdf:value "2012"^^xsd:gYear .
+[ rdf:value "2012"^^xsd:gYear ] .

--- a/test-suite/test-cases/rdfa1.1-lite/html5/0282.ttl
+++ b/test-suite/test-cases/rdfa1.1-lite/html5/0282.ttl
@@ -1,4 +1,4 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<http://rdfa.info/test-suite/test-cases/rdfa1.1-lite/html5/0282.html> rdf:value "2012-03"^^xsd:gYearMonth .
+[ rdf:value "2012-03"^^xsd:gYearMonth ] .

--- a/test-suite/test-cases/rdfa1.1-lite/xhtml5/0281.ttl
+++ b/test-suite/test-cases/rdfa1.1-lite/xhtml5/0281.ttl
@@ -1,4 +1,4 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<http://rdfa.info/test-suite/test-cases/rdfa1.1-lite/xhtml5/0281.xhtml> rdf:value "2012"^^xsd:gYear .
+[ rdf:value "2012"^^xsd:gYear ] .

--- a/test-suite/test-cases/rdfa1.1-lite/xhtml5/0282.ttl
+++ b/test-suite/test-cases/rdfa1.1-lite/xhtml5/0282.ttl
@@ -1,4 +1,4 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<http://rdfa.info/test-suite/test-cases/rdfa1.1-lite/xhtml5/0282.xhtml> rdf:value "2012-03"^^xsd:gYearMonth .
+[ rdf:value "2012-03"^^xsd:gYearMonth ] .

--- a/test-suite/test-cases/rdfa1.1-lite/xml/0214.ttl
+++ b/test-suite/test-cases/rdfa1.1-lite/xml/0214.ttl
@@ -3,7 +3,7 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
- [
-     a foaf:Document;
-     dcterms:title "Test 0214"
- ] .
+<http://rdfa.info/test-suite/test-cases/rdfa1.1-lite/xml/0214.xml>
+   a foaf:Document;
+   dcterms:title "Test 0214";
+   .

--- a/test-suite/test-cases/rdfa1.1-lite/xml/0264.ttl
+++ b/test-suite/test-cases/rdfa1.1-lite/xml/0264.ttl
@@ -1,0 +1,1 @@
+<http://rdfa.info/test-suite/test-cases/rdfa1.1-lite/xml/0264.xml> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <http://www.example.org> .

--- a/test-suite/test-cases/rdfa1.1/html4/0180.ttl
+++ b/test-suite/test-cases/rdfa1.1/html4/0180.ttl
@@ -1,4 +1,3 @@
-@prefix xhv: <http://www.w3.org/1999/xhtml/vocab#> .
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
 
-<http://example.org/#me> xhv:name "Ivan Herman" .
+<http://example.org/#me> foaf:name "Ivan Herman" .

--- a/test-suite/test-cases/rdfa1.1/html5-invalid/0180.ttl
+++ b/test-suite/test-cases/rdfa1.1/html5-invalid/0180.ttl
@@ -1,4 +1,3 @@
-@prefix xhv: <http://www.w3.org/1999/xhtml/vocab#> .
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
 
-<http://example.org/#me> xhv:name "Ivan Herman" .
+<http://example.org/#me> foaf:name "Ivan Herman" .

--- a/test-suite/test-cases/rdfa1.1/html5-invalid/0280.ttl
+++ b/test-suite/test-cases/rdfa1.1/html5-invalid/0280.ttl
@@ -1,4 +1,4 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<http://rdfa.info/test-suite/test-cases/rdfa1.1/html5-invalid/0280.html> rdf:value "P2011Y06M28DT00H00M00S"^^xsd:duration .
+[ rdf:value "P2011Y06M28DT00H00M00S"^^xsd:duration ] .

--- a/test-suite/test-cases/rdfa1.1/html5/0279.ttl
+++ b/test-suite/test-cases/rdfa1.1/html5/0279.ttl
@@ -1,4 +1,4 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<http://rdfa.info/test-suite/test-cases/rdfa1.1/html5/0279.html> rdf:value "2012-03-18T00:00:00Z"^^xsd:date .
+[ rdf:value "2012-03-18T00:00:00Z"^^xsd:date ] .

--- a/test-suite/test-cases/rdfa1.1/html5/0281.ttl
+++ b/test-suite/test-cases/rdfa1.1/html5/0281.ttl
@@ -1,4 +1,4 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<http://rdfa.info/test-suite/test-cases/rdfa1.1/html5/0281.html> rdf:value "2012"^^xsd:gYear .
+[ rdf:value "2012"^^xsd:gYear ] .

--- a/test-suite/test-cases/rdfa1.1/html5/0282.ttl
+++ b/test-suite/test-cases/rdfa1.1/html5/0282.ttl
@@ -1,4 +1,4 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<http://rdfa.info/test-suite/test-cases/rdfa1.1/html5/0282.html> rdf:value "2012-03"^^xsd:gYearMonth .
+[ rdf:value "2012-03"^^xsd:gYearMonth ] .

--- a/test-suite/test-cases/rdfa1.1/html5/0284.ttl
+++ b/test-suite/test-cases/rdfa1.1/html5/0284.ttl
@@ -1,4 +1,4 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<http://rdfa.info/test-suite/test-cases/rdfa1.1/html5/0284.html> rdf:value " 2012-03-18"^^xsd:dateTime .
+[ rdf:value " 2012-03-18"^^xsd:dateTime ] .

--- a/test-suite/test-cases/rdfa1.1/xhtml1/0061.ttl
+++ b/test-suite/test-cases/rdfa1.1/xhtml1/0061.ttl
@@ -1,0 +1,1 @@
+<http://rdfa.info/test-suite/test-cases/rdfa1.1/xhtml1/0061.xhtml> <http://www.w3.org/1999/xhtml/vocab#next> <http://rdfa.info/test-suite/test-cases/rdfa1.1/xhtml1/0062.xhtml> .

--- a/test-suite/test-cases/rdfa1.1/xhtml1/0062.ttl
+++ b/test-suite/test-cases/rdfa1.1/xhtml1/0062.ttl
@@ -1,0 +1,1 @@
+<http://rdfa.info/test-suite/test-cases/rdfa1.1/xhtml1/0063.xhtml> <http://www.w3.org/1999/xhtml/vocab#prev> <http://rdfa.info/test-suite/test-cases/rdfa1.1/xhtml1/0062.xhtml> .

--- a/test-suite/test-cases/rdfa1.1/xhtml1/0076.ttl
+++ b/test-suite/test-cases/rdfa1.1/xhtml1/0076.ttl
@@ -1,4 +1,27 @@
 @prefix xhv: <http://www.w3.org/1999/xhtml/vocab#> .
 
-<http://rdfa.info/test-suite/test-cases/rdfa1.1/xhtml1/0076.xhtml> xhv:license <http://example.org/license>;
-   xhv:role <http://example.org/role> .
+<http://rdfa.info/test-suite/test-cases/rdfa1.1/xhtml1/0076.xhtml>
+   xhv:alternate <http://example.org/alternate> ;
+   xhv:appendix <http://example.org/appendix> ;
+   xhv:bookmark <http://example.org/bookmark> ;
+   xhv:cite <http://example.org/cite> ;
+   xhv:chapter <http://example.org/chapter> ;
+   xhv:contents <http://example.org/contents> ;
+   xhv:copyright <http://example.org/copyright> ;
+   xhv:glossary <http://example.org/glossary> ;
+   xhv:help <http://example.org/help> ;
+   xhv:icon <http://example.org/icon> ;
+   xhv:index <http://example.org/index> ;
+   xhv:meta <http://example.org/meta> ;
+   xhv:next <http://example.org/next> ;
+   xhv:p3pv1 <http://example.org/p3pv1> ;
+   xhv:prev <http://example.org/prev> ;
+   xhv:role <http://example.org/role> ;
+   xhv:section <http://example.org/section> ;
+   xhv:subsection <http://example.org/subsection> ;
+   xhv:start <http://example.org/start> ;
+   xhv:license <http://example.org/license> ;
+   xhv:up <http://example.org/up> ;
+   xhv:last <http://example.org/last> ;
+   xhv:stylesheet <http://example.org/stylesheet> ;
+   .

--- a/test-suite/test-cases/rdfa1.1/xhtml1/0077.ttl
+++ b/test-suite/test-cases/rdfa1.1/xhtml1/0077.ttl
@@ -1,4 +1,28 @@
 @prefix xhv: <http://www.w3.org/1999/xhtml/vocab#> .
 
-<http://rdfa.info/test-suite/test-cases/rdfa1.1/xhtml1/0077.xhtml> xhv:license <http://example.org/license>;
-   xhv:role <http://example.org/role> .
+<http://rdfa.info/test-suite/test-cases/rdfa1.1/xhtml1/0077.xhtml>
+   xhv:alternate <http://example.org/alternate> ;
+   xhv:appendix <http://example.org/appendix> ;
+   xhv:bookmark <http://example.org/bookmark> ;
+   xhv:cite <http://example.org/cite> ;
+   xhv:chapter <http://example.org/chapter> ;
+   xhv:contents <http://example.org/contents> ;
+   xhv:copyright <http://example.org/copyright> ;
+   xhv:glossary <http://example.org/glossary> ;
+   xhv:help <http://example.org/help> ;
+   xhv:icon <http://example.org/icon> ;
+   xhv:index <http://example.org/index> ;
+   xhv:meta <http://example.org/meta> ;
+   xhv:next <http://example.org/next> ;
+   xhv:p3pv1 <http://example.org/p3pv1> ;
+   xhv:prev <http://example.org/prev> ;
+   xhv:role <http://example.org/role> ;
+   xhv:section <http://example.org/section> ;
+   xhv:subsection <http://example.org/subsection> ;
+   xhv:start <http://example.org/start> ;
+   xhv:license <http://example.org/license> ;
+   xhv:up <http://example.org/up> ;
+   xhv:first <http://example.org/first> ;
+   xhv:last <http://example.org/last> ;
+   xhv:stylesheet <http://example.org/stylesheet> ;
+   .

--- a/test-suite/test-cases/rdfa1.1/xhtml1/0121.ttl
+++ b/test-suite/test-cases/rdfa1.1/xhtml1/0121.ttl
@@ -1,6 +1,6 @@
 @prefix dc11: <http://purl.org/dc/elements/1.1/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<http://example.org/> dc11:title "Test Case 0121" .
-
-<http://rdfa.info/test-suite/test-cases/rdfa1.1/xhtml1/0121.xhtml> dc11:contributor "Shane McCarron" .
+<http://example.org/>
+  dc11:title "Test Case 0121" ;
+  dc11:contributor "Shane McCarron" .

--- a/test-suite/test-cases/rdfa1.1/xhtml1/0180.ttl
+++ b/test-suite/test-cases/rdfa1.1/xhtml1/0180.ttl
@@ -1,4 +1,3 @@
-@prefix xhv: <http://www.w3.org/1999/xhtml/vocab#> .
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
 
-<http://example.org/#me> xhv:name "Ivan Herman" .
+<http://example.org/#me> foaf:name "Ivan Herman" .

--- a/test-suite/test-cases/rdfa1.1/xhtml1/0198.ttl
+++ b/test-suite/test-cases/rdfa1.1/xhtml1/0198.ttl
@@ -4,5 +4,5 @@
 
 <http://www.example.org/me#mark> a foaf:Person;
    foaf:firstName "Mark";
-   foaf:name "<span property=\"foaf:firstName\">Mark</span> <span property=\"foaf:surname\">Birbeck</span><span xmlns=\"http://www.w3.org/1999/xhtml\" property=\"foaf:firstName\">Mark</span><span xmlns=\"http://www.w3.org/1999/xhtml\" property=\"foaf:surname\">Birbeck</span>"^^rdf:XMLLiteral;
+   foaf:name "<span property=\"foaf:firstName\" xmlns=\"http://www.w3.org/1999/xhtml\" xmlns:foaf=\"http://xmlns.com/foaf/0.1/\" xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\">Mark</span> <span property=\"foaf:surname\" xmlns=\"http://www.w3.org/1999/xhtml\" xmlns:foaf=\"http://xmlns.com/foaf/0.1/\" xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\">Birbeck</span>"^^rdf:XMLLiteral;
    foaf:surname "Birbeck" .

--- a/test-suite/test-cases/rdfa1.1/xhtml1/0260.ttl
+++ b/test-suite/test-cases/rdfa1.1/xhtml1/0260.ttl
@@ -1,4 +1,33 @@
 @prefix xhv: <http://www.w3.org/1999/xhtml/vocab#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<http://rdfa.info/test-suite/test-cases/rdfa1.1/xhtml1/0260.xhtml> xhv:license "license" .
+[
+  # Vocabulary Terms
+  xhv:alternate "alternate";
+  xhv:appendix "appendix";
+  xhv:cite "cite";
+  xhv:bookmark "bookmark";
+  xhv:contents "contents";
+  xhv:chapter "chapter";
+  xhv:copyright "copyright";
+  xhv:first "first";
+  xhv:glossary "glossary";
+  xhv:help "help";
+  xhv:icon "icon";
+  xhv:index "index";
+  xhv:last "last";
+  xhv:license "license";
+  xhv:meta "meta";
+  xhv:next "next";
+  xhv:prev "prev";
+  xhv:previous "previous";
+  xhv:section "section";
+  xhv:start "start";
+  xhv:stylesheet "stylesheet";
+  xhv:subsection "subsection";
+  xhv:top "top";
+  xhv:up "up";
+
+  # Other terms
+  xhv:p3pv1 "p3pv1"
+] .

--- a/test-suite/test-cases/rdfa1.1/xhtml5-invalid/0180.ttl
+++ b/test-suite/test-cases/rdfa1.1/xhtml5-invalid/0180.ttl
@@ -1,4 +1,3 @@
-@prefix xhv: <http://www.w3.org/1999/xhtml/vocab#> .
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
 
-<http://example.org/#me> xhv:name "Ivan Herman" .
+<http://example.org/#me> foaf:name "Ivan Herman" .

--- a/test-suite/test-cases/rdfa1.1/xhtml5-invalid/0280.ttl
+++ b/test-suite/test-cases/rdfa1.1/xhtml5-invalid/0280.ttl
@@ -1,4 +1,4 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<http://rdfa.info/test-suite/test-cases/rdfa1.1/xhtml5-invalid/0280.xhtml> rdf:value "P2011Y06M28DT00H00M00S"^^xsd:duration .
+[ rdf:value "P2011Y06M28DT00H00M00S"^^xsd:duration ] .

--- a/test-suite/test-cases/rdfa1.1/xhtml5/0121.ttl
+++ b/test-suite/test-cases/rdfa1.1/xhtml5/0121.ttl
@@ -1,6 +1,6 @@
 @prefix dc11: <http://purl.org/dc/elements/1.1/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<http://example.org/> dc11:title "Test Case 0121" .
-
-<http://rdfa.info/test-suite/test-cases/rdfa1.1/xhtml5/0121.xhtml> dc11:contributor "Shane McCarron" .
+<http://example.org/>
+  dc11:title "Test Case 0121" ;
+  dc11:contributor "Shane McCarron" .

--- a/test-suite/test-cases/rdfa1.1/xhtml5/0279.ttl
+++ b/test-suite/test-cases/rdfa1.1/xhtml5/0279.ttl
@@ -1,4 +1,4 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<http://rdfa.info/test-suite/test-cases/rdfa1.1/xhtml5/0279.xhtml> rdf:value "2012-03-18T00:00:00Z"^^xsd:date .
+[ rdf:value "2012-03-18T00:00:00Z"^^xsd:date ] .

--- a/test-suite/test-cases/rdfa1.1/xhtml5/0281.ttl
+++ b/test-suite/test-cases/rdfa1.1/xhtml5/0281.ttl
@@ -1,4 +1,4 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<http://rdfa.info/test-suite/test-cases/rdfa1.1/xhtml5/0281.xhtml> rdf:value "2012"^^xsd:gYear .
+[ rdf:value "2012"^^xsd:gYear ] .

--- a/test-suite/test-cases/rdfa1.1/xhtml5/0282.ttl
+++ b/test-suite/test-cases/rdfa1.1/xhtml5/0282.ttl
@@ -1,4 +1,4 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<http://rdfa.info/test-suite/test-cases/rdfa1.1/xhtml5/0282.xhtml> rdf:value "2012-03"^^xsd:gYearMonth .
+[ rdf:value "2012-03"^^xsd:gYearMonth ] .

--- a/test-suite/test-cases/rdfa1.1/xhtml5/0284.ttl
+++ b/test-suite/test-cases/rdfa1.1/xhtml5/0284.ttl
@@ -1,4 +1,4 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<http://rdfa.info/test-suite/test-cases/rdfa1.1/xhtml5/0284.xhtml> rdf:value " 2012-03-18"^^xsd:dateTime .
+[ rdf:value " 2012-03-18"^^xsd:dateTime ] .

--- a/test-suite/test-cases/rdfa1.1/xml/0013.ttl
+++ b/test-suite/test-cases/rdfa1.1/xml/0013.ttl
@@ -1,4 +1,4 @@
 @prefix ex: <http://example.org/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-ex:node ex:property "chat" .
+ex:node ex:property "chat"@fr .

--- a/test-suite/test-cases/rdfa1.1/xml/0180.ttl
+++ b/test-suite/test-cases/rdfa1.1/xml/0180.ttl
@@ -1,4 +1,4 @@
 @prefix xhv: <http://www.w3.org/1999/xhtml/vocab#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<http://rdfa.info/test-suite/test-cases/rdfa1.1/xml/0180.xml#me> xhv:name "Ivan Herman" .
+<http://example.org/#me> xhv:name "Ivan Herman" .

--- a/test-suite/test-cases/rdfa1.1/xml/0202.ttl
+++ b/test-suite/test-cases/rdfa1.1/xml/0202.ttl
@@ -1,4 +1,4 @@
 @prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<http://rdfa.info/test-suite/test-cases/rdfa1.1/xml/0202.xml> dcterms:description "A yellow rectangle with sharp corners." .
+<http://example.com/> dcterms:description "A yellow rectangle with sharp corners." .

--- a/test-suite/test-cases/rdfa1.1/xml/0203.ttl
+++ b/test-suite/test-cases/rdfa1.1/xml/0203.ttl
@@ -1,4 +1,4 @@
 @prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<http://rdfa.info/test-suite/test-cases/rdfa1.1/xml/0203.xml> dcterms:description "A yellow rectangle with sharp corners." .
+<http://example.com/> dcterms:description "A yellow rectangle with sharp corners." .

--- a/test-suite/test-cases/rdfa1.1/xml/0214.ttl
+++ b/test-suite/test-cases/rdfa1.1/xml/0214.ttl
@@ -3,7 +3,5 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
- [
-     a foaf:Document;
-     dcterms:title "Test 0214"
- ] .
+<http://rdfa.info/test-suite/test-cases/rdfa1.1/xml/0214.xml> a foaf:Document;
+        dcterms:title "Test 0214" .

--- a/test-suite/test-cases/rdfa1.1/xml/0264.ttl
+++ b/test-suite/test-cases/rdfa1.1/xml/0264.ttl
@@ -1,0 +1,1 @@
+<http://rdfa.info/test-suite/test-cases/rdfa1.1/xml/0264.xml> <http://www.w3.org/2000/01/rdf-schema#seeAlso> <http://www.example.org> .

--- a/test-suite/test-cases/rdfa1.1/xml/0265.ttl
+++ b/test-suite/test-cases/rdfa1.1/xml/0265.ttl
@@ -1,0 +1,3 @@
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+<http://www.example.com> rdfs:seeAlso <http://www.example.org> .

--- a/test-suite/test-cases/rdfa1.1/xml/0271.ttl
+++ b/test-suite/test-cases/rdfa1.1/xml/0271.ttl
@@ -1,0 +1,3 @@
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+<http://www.example.org/> rdfs:comment "This is an RDFa test" .


### PR DESCRIPTION
I wrote a script to go through all the positive tests and identify the .ttl files that mismatched the .sparql files. This is a PR for my fixes.

Here's the script I used:

```ruby
require 'json'
require 'json/ld'
require 'rdf'
require 'rdf/turtle'
require 'sparql'

graph = JSON.parse(File.read('test-suite/manifest.jsonld'))
graph["@graph"].each do |test|
	if test["@type"]=="test:TestCase" and test["expectedResults"]==true
		#puts test["num"]
		Dir.glob("test-suite/test-cases/*/*/"+test["num"]+".sparql").each do |sparqlfilename|
			begin
				print sparqlfilename + "\t"
				sse = SPARQL.parse(File.read(sparqlfilename))
			rescue Exception => e
				puts "Error: "+sparqlfilename
				STDERR.puts e.inspect
			end
			begin
				#print ttlfilename + "\t"
				ttlfilename = sparqlfilename.sub(/\.sparql$/, ".ttl")
				queryable = RDF::Repository.load(ttlfilename, format:  :ttl)
				sse.execute(queryable) do |result|
				  puts result.inspect
				end
			rescue Exception => e
				puts "Error: "+ttlfilename
				STDERR.puts e.inspect
			end
		end
	end
end
```

It reports parsing errors for a handful of files:

* test-suite/test-cases/rdfa1.1/html5/0279.ttl
* test-suite/test-cases/rdfa1.1/xhtml5/0279.ttl
* test-suite/test-cases/rdfa1.1/html5/0284.ttl
* test-suite/test-cases/rdfa1.1/xhtml5/0284.ttl

I believe that's a feature of the parser (I think it's complaining about strings outside the lexical value space of xsd:dateTime), but you might want to double-check.
