### PR TITLE
Fix incorrect tests

### DIFF
--- a/_data/tests/0121.txt
+++ b/_data/tests/0121.txt
@@ -4,14 +4,14 @@
    </head>
    <body>
     <div>
-	<p about="http://example.org/">
+	<div about="http://example.org/">
 		<span about="[]" property="dc:title">Test Case 0121</span>
 		checks to make sure RDFa processors resolve the empty CURIE correctly.
 		<p resource="[]">
 			<span property="dc:contributor">Shane McCarron</span>
 			contributed to this test.
 		</p>
-	</p>
+	</div>
 	</div>
    </body>
 

--- a/_data/tests/0260.sparql
+++ b/_data/tests/0260.sparql
@@ -1,7 +1,7 @@
 PREFIX xhv: <http://www.w3.org/1999/xhtml/vocab#>
 
 ASK WHERE {
-  [
+  <$TCPATH/0260.xhtml>
     # Vocabulary Terms
     xhv:alternate "alternate";
     xhv:appendix "appendix";
@@ -30,5 +30,5 @@ ASK WHERE {
     
     # Other terms
     xhv:p3pv1 "p3pv1"
-  ]
+  .
 }

--- a/_data/tests/0279.sparql
+++ b/_data/tests/0279.sparql
@@ -2,5 +2,5 @@ PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 ASK WHERE {
-  [ rdf:value "2012-03-18T00:00:00Z"^^xsd:date ] .
+  <$TCPATH/0279.xhtml> rdf:value "2012-03-18T00:00:00Z"^^xsd:date .
 }

--- a/_data/tests/0281.sparql
+++ b/_data/tests/0281.sparql
@@ -2,5 +2,5 @@ PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 ASK WHERE {
-  [ rdf:value "2012"^^xsd:gYear ] .
+  <$TCPATH/0281.xhtml> rdf:value "2012"^^xsd:gYear .
 }

--- a/_data/tests/0282.sparql
+++ b/_data/tests/0282.sparql
@@ -2,5 +2,5 @@ PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 ASK WHERE {
-  [ rdf:value "2012-03"^^xsd:gYearMonth ] .
+  <$TCPATH/0282.xhtml> rdf:value "2012-03"^^xsd:gYearMonth .
 }

--- a/_data/tests/0284.sparql
+++ b/_data/tests/0284.sparql
@@ -2,5 +2,5 @@ PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 ASK WHERE {
-  [ rdf:value " 2012-03-18"^^xsd:dateTime ] .
+  <$TCPATH/0284.xhtml> rdf:value " 2012-03-18"^^xsd:dateTime .
 }

--- a/_data/tests/0295.txt
+++ b/_data/tests/0295.txt
@@ -475,11 +475,11 @@ resource="[_:b]">knows</span>
          <p about="">This is <span property="dc:title">Test 0109</span>.</p>
       </div>
     <div rel="xhv:next">
-      <div rel="xhv:next" />
+      <img rel="xhv:next" />
     </div>
     <div rel="xhv:next">
       <div rel="xhv:next">
-        <div rel="xhv:next" />
+        <img rel="xhv:next" />
       </div>
     </div>
   	  <p>
@@ -531,14 +531,14 @@ whitespace     preserved
 	         is the default prefix for XHTML+RDFa 1.0.
 	      </p>
     <div>
-	<p about="http://example.org/">
+	<div about="http://example.org/">
 		<span about="[]" property="dc:title">Test Case 0121</span>
 		checks to make sure RDFa processors resolve the empty CURIE correctly.
 		<p resource="[]">
 			<span property="dc:contributor">Shane McCarron</span>
 			contributed to this test.
 		</p>
-	</p>
+	</div>
 	</div>
     <p about="http://example.org/section1.html">
          This section is contained below <span rel="up" resource="[]">the main site</span>.
@@ -867,7 +867,7 @@ an XMLLiteral</p>
     Non matching lexical value with language.
   </time>
   <data property="rdf:value" lang="lat" value="veni, vidi, vici" content="I came, I saw, I conquered">
-    @value overrides @content in the 'data' element.
+    @value does not override @content in the 'data' element.
   </data>
   <time property="rdf:value" datetime="2012-03-18T00:00:00-08:00">18 March 2012 at midnight in San Francisco</time>
   <object property="rdf:value" data="http://example.com/"></object>

--- a/_data/tests/0304.sparql
+++ b/_data/tests/0304.sparql
@@ -1,5 +1,4 @@
 ASK WHERE {
-	<http://example.net/> <http://purl.org/dc/terms/title> "Test 0304" .
 	<http://example.net/> <http://purl.org/dc/terms/description> "A yellow rectangle with sharp corners." .
 }
 

--- a/_data/tests/0325.sparql
+++ b/_data/tests/0325.sparql
@@ -1,7 +1,7 @@
 BASE <http://example.org/>
 PREFIX schema: <http://schema.org/>
 ASK WHERE {
-  #foo schema:refers-to _:p .
-  #bar schema:refers-to _:p .
+  <#foo> schema:refers-to _:p .
+  <#bar> schema:refers-to _:p .
   _:p schema:name "Amanda" .
 }

--- a/test-suite/test-cases/rdfa1.0/svg/0304.sparql
+++ b/test-suite/test-cases/rdfa1.0/svg/0304.sparql
@@ -1,5 +1,4 @@
 ASK WHERE {
-	<http://example.net/> <http://purl.org/dc/terms/title> "Test 0304" .
 	<http://example.net/> <http://purl.org/dc/terms/description> "A yellow rectangle with sharp corners." .
 }
 

--- a/test-suite/test-cases/rdfa1.0/xhtml1/0121.xhtml
+++ b/test-suite/test-cases/rdfa1.0/xhtml1/0121.xhtml
@@ -6,14 +6,14 @@
    </head>
    <body>
     <div>
-	<p about="http://example.org/">
+	<div about="http://example.org/">
 		<span about="[]" property="dc:title">Test Case 0121</span>
 		checks to make sure RDFa processors resolve the empty CURIE correctly.
 		<p resource="[]">
 			<span property="dc:contributor">Shane McCarron</span>
 			contributed to this test.
 		</p>
-	</p>
+	</div>
 	</div>
    </body>
 

--- a/test-suite/test-cases/rdfa1.0/xml/0121.xml
+++ b/test-suite/test-cases/rdfa1.0/xml/0121.xml
@@ -5,14 +5,14 @@
    </head>
    <body>
     <div>
-	<p about="http://example.org/">
+	<div about="http://example.org/">
 		<span about="[]" property="dc:title">Test Case 0121</span>
 		checks to make sure RDFa processors resolve the empty CURIE correctly.
 		<p resource="[]">
 			<span property="dc:contributor">Shane McCarron</span>
 			contributed to this test.
 		</p>
-	</p>
+	</div>
 	</div>
    </body>
 

--- a/test-suite/test-cases/rdfa1.1-lite/html5/0281.sparql
+++ b/test-suite/test-cases/rdfa1.1-lite/html5/0281.sparql
@@ -2,5 +2,5 @@ PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 ASK WHERE {
-  [ rdf:value "2012"^^xsd:gYear ] .
+  <http://rdfa.info/test-suite/test-cases/rdfa1.1-lite/html5/0281.html> rdf:value "2012"^^xsd:gYear .
 }

--- a/test-suite/test-cases/rdfa1.1-lite/html5/0281.ttl
+++ b/test-suite/test-cases/rdfa1.1-lite/html5/0281.ttl
@@ -1,4 +1,4 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-[ rdf:value "2012"^^xsd:gYear ] .
+<<http://rdfa.info/test-suite/test-cases/rdfa1.1/html5/0284.html>> rdf:value "2012"^^xsd:gYear .

--- a/test-suite/test-cases/rdfa1.1-lite/html5/0282.sparql
+++ b/test-suite/test-cases/rdfa1.1-lite/html5/0282.sparql
@@ -2,5 +2,5 @@ PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 ASK WHERE {
-  [ rdf:value "2012-03"^^xsd:gYearMonth ] .
+  <http://rdfa.info/test-suite/test-cases/rdfa1.1-lite/html5/0282.html> rdf:value "2012-03"^^xsd:gYearMonth .
 }

--- a/test-suite/test-cases/rdfa1.1-lite/html5/0282.ttl
+++ b/test-suite/test-cases/rdfa1.1-lite/html5/0282.ttl
@@ -1,4 +1,4 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-[ rdf:value "2012-03"^^xsd:gYearMonth ] .
+<<http://rdfa.info/test-suite/test-cases/rdfa1.1/html5/0282.html>> rdf:value "2012-03"^^xsd:gYearMonth .

--- a/test-suite/test-cases/rdfa1.1-lite/html5/0325.sparql
+++ b/test-suite/test-cases/rdfa1.1-lite/html5/0325.sparql
@@ -1,7 +1,7 @@
 BASE <http://example.org/>
 PREFIX schema: <http://schema.org/>
 ASK WHERE {
-  #foo schema:refers-to _:p .
-  #bar schema:refers-to _:p .
+  <#foo> schema:refers-to _:p .
+  <#bar> schema:refers-to _:p .
   _:p schema:name "Amanda" .
 }

--- a/test-suite/test-cases/rdfa1.1-lite/xhtml5/0281.sparql
+++ b/test-suite/test-cases/rdfa1.1-lite/xhtml5/0281.sparql
@@ -2,5 +2,5 @@ PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 ASK WHERE {
-  [ rdf:value "2012"^^xsd:gYear ] .
+  <http://rdfa.info/test-suite/test-cases/rdfa1.1-lite/xhtml5/0281.xhtml> rdf:value "2012"^^xsd:gYear .
 }

--- a/test-suite/test-cases/rdfa1.1-lite/xhtml5/0281.ttl
+++ b/test-suite/test-cases/rdfa1.1-lite/xhtml5/0281.ttl
@@ -1,4 +1,4 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-[ rdf:value "2012"^^xsd:gYear ] .
+<http://rdfa.info/test-suite/test-cases/rdfa1.1/xhtml5/0281.xhtml> rdf:value "2012"^^xsd:gYear .

--- a/test-suite/test-cases/rdfa1.1-lite/xhtml5/0282.sparql
+++ b/test-suite/test-cases/rdfa1.1-lite/xhtml5/0282.sparql
@@ -2,5 +2,5 @@ PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 ASK WHERE {
-  [ rdf:value "2012-03"^^xsd:gYearMonth ] .
+  <http://rdfa.info/test-suite/test-cases/rdfa1.1-lite/xhtml5/0282.xhtml> rdf:value "2012-03"^^xsd:gYearMonth .
 }

--- a/test-suite/test-cases/rdfa1.1-lite/xhtml5/0282.ttl
+++ b/test-suite/test-cases/rdfa1.1-lite/xhtml5/0282.ttl
@@ -1,4 +1,4 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-[ rdf:value "2012-03"^^xsd:gYearMonth ] .
+<http://rdfa.info/test-suite/test-cases/rdfa1.1/xhtml5/0282.xhtml> rdf:value "2012-03"^^xsd:gYearMonth .

--- a/test-suite/test-cases/rdfa1.1-lite/xhtml5/0325.sparql
+++ b/test-suite/test-cases/rdfa1.1-lite/xhtml5/0325.sparql
@@ -1,7 +1,7 @@
 BASE <http://example.org/>
 PREFIX schema: <http://schema.org/>
 ASK WHERE {
-  #foo schema:refers-to _:p .
-  #bar schema:refers-to _:p .
+  <#foo> schema:refers-to _:p .
+  <#bar> schema:refers-to _:p .
   _:p schema:name "Amanda" .
 }

--- a/test-suite/test-cases/rdfa1.1/html4/0295.html
+++ b/test-suite/test-cases/rdfa1.1/html4/0295.html
@@ -450,11 +450,11 @@ resource="[_:b]">knows</span>
          <p about="">This is <span property="dc:title">Test 0109</span>.</p>
       </div>
     <div rel="xhv:next">
-      <div rel="xhv:next" />
+      <img rel="xhv:next" />
     </div>
     <div rel="xhv:next">
       <div rel="xhv:next">
-        <div rel="xhv:next" />
+        <img rel="xhv:next" />
       </div>
     </div>
   	  <p>
@@ -506,14 +506,14 @@ whitespace     preserved
 	         is the default prefix for XHTML+RDFa 1.0.
 	      </p>
     <div>
-	<p about="http://example.org/">
+	<div about="http://example.org/">
 		<span about="[]" property="dc:title">Test Case 0121</span>
 		checks to make sure RDFa processors resolve the empty CURIE correctly.
 		<p resource="[]">
 			<span property="dc:contributor">Shane McCarron</span>
 			contributed to this test.
 		</p>
-	</p>
+	</div>
 	</div>
     <p about="http://example.org/section1.html">
          This section is contained below <span rel="up" resource="[]">the main site</span>.
@@ -842,7 +842,7 @@ an XMLLiteral</p>
     Non matching lexical value with language.
   </time>
   <data property="rdf:value" lang="lat" value="veni, vidi, vici" content="I came, I saw, I conquered">
-    @value overrides @content in the 'data' element.
+    @value does not override @content in the 'data' element.
   </data>
   <time property="rdf:value" datetime="2012-03-18T00:00:00-08:00">18 March 2012 at midnight in San Francisco</time>
   <object property="rdf:value" data="http://example.com/"></object>

--- a/test-suite/test-cases/rdfa1.1/html4/0295.ttl
+++ b/test-suite/test-cases/rdfa1.1/html4/0295.ttl
@@ -35,7 +35,8 @@
 
 xmlzzz: dct:title "Test Case 0121",
      "Example Website";
-   rdf:value "value" .
+   rdf:value "value" ;
+   dct:contributor "Shane McCarron" .
 
 xmlzzz:example.png a :Image;
    xhv:license <http://creativecommons.org/licenses/by-nc-sa/2.0/> .
@@ -92,9 +93,9 @@ xmlzzz:jd vcard:fn "John Doe" .
      <http://creativecommons.org/licenses/by-nd/3.0/>;
    xhv:meta xmlzzz:meta;
    xhv:next <http://rdfa.info/test-suite/test-cases/rdfa1.1/html4/0070.html>,
-     xmlzzz:next,  [ xhv:next <http://rdfa.info/test-suite/test-cases/rdfa1.1/html4/0295.html#b>,
-       xmlzzz:node,
-       <http://rdfa.info/test-suite/test-cases/rdfa1.1/html4/0295.html#a>,  [ xhv:next []]];
+     [ xhv:next [] ],
+	 [],
+	 xmlzzz:next;
    xhv:p3pv1 xmlzzz:p3pv1;
    xhv:prev <http://rdfa.info/test-suite/test-cases/rdfa1.1/html4/0069.html>,
      xmlzzz:prev;
@@ -129,7 +130,7 @@ xmlzzz:jd vcard:fn "John Doe" .
 
 <http://rdfa.info/test-suite/test-cases/rdfa1.1/html4/0295.html#mark> a :Person;
    :firstName "Mark";
-   :name "<span property=\"foaf:firstName\">Mark</span> <span property=\"foaf:surname\">Birbeck</span><span xmlns=\"http://www.w3.org/1999/xhtml\" property=\"foaf:firstName\">Mark</span><span xmlns=\"http://www.w3.org/1999/xhtml\" property=\"foaf:surname\">Birbeck</span>"^^rdf:XMLLiteral;
+   :name "<span property=\"foaf:firstName\" xmlns:air=\"http://www.daml.org/2001/10/html/airport-ont#\" xmlns:bio=\"http://vocab.org/bio/0.1/\" xmlns:cal=\"http://www.w3.org/2002/12/cal/icaltzd#\" xmlns:cc=\"http://creativecommons.org/ns#\" xmlns:cert=\"http://www.w3.org/ns/auth/cert#\" xmlns:contact=\"http://www.w3.org/2000/10/swap/pim/contact#\" xmlns:dc=\"http://purl.org/dc/terms/\" xmlns:dct=\"http://purl.org/dc/terms/\" xmlns:earl=\"http://www.w3.org/ns/earl#\" xmlns:ex=\"http://example.org/\" xmlns:example=\"http://example.org/\" xmlns:foaf=\"http://xmlns.com/foaf/0.1/\" xmlns:google=\"http://rdf.data-vocabulary.org/#\" xmlns:ical=\"http://www.w3.org/2002/12/cal/icaltzd#\" xmlns:openid=\"http://xmlns.openid.net/auth#\" xmlns:owl=\"http://www.w3.org/2002/07/owl#\" xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\" xmlns:rdfatest=\"http://rdfa.info/vocabs/rdfa-test#\" xmlns:rdfs=\"http://www.w3.org/2000/01/rdf-schema#\" xmlns:rel=\"http://vocab.org/relationship/\" xmlns:rsa=\"http://www.w3.org/ns/auth/rsa#\" xmlns:rss=\"http://web.resource.org/rss/1.0/\" xmlns:sioc=\"http://rdfs.org/sioc/ns#\" xmlns:v=\"http://www.w3.org/2006/vcard/ns#\" xmlns:wot=\"http://xmlns.com/wot/0.1/\" xmlns:xhv=\"http://www.w3.org/1999/xhtml/vocab#\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema#\">Mark</span> <span property=\"foaf:surname\" xmlns:air=\"http://www.daml.org/2001/10/html/airport-ont#\" xmlns:bio=\"http://vocab.org/bio/0.1/\" xmlns:cal=\"http://www.w3.org/2002/12/cal/icaltzd#\" xmlns:cc=\"http://creativecommons.org/ns#\" xmlns:cert=\"http://www.w3.org/ns/auth/cert#\" xmlns:contact=\"http://www.w3.org/2000/10/swap/pim/contact#\" xmlns:dc=\"http://purl.org/dc/terms/\" xmlns:dct=\"http://purl.org/dc/terms/\" xmlns:earl=\"http://www.w3.org/ns/earl#\" xmlns:ex=\"http://example.org/\" xmlns:example=\"http://example.org/\" xmlns:foaf=\"http://xmlns.com/foaf/0.1/\" xmlns:google=\"http://rdf.data-vocabulary.org/#\" xmlns:ical=\"http://www.w3.org/2002/12/cal/icaltzd#\" xmlns:openid=\"http://xmlns.openid.net/auth#\" xmlns:owl=\"http://www.w3.org/2002/07/owl#\" xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\" xmlns:rdfatest=\"http://rdfa.info/vocabs/rdfa-test#\" xmlns:rdfs=\"http://www.w3.org/2000/01/rdf-schema#\" xmlns:rel=\"http://vocab.org/relationship/\" xmlns:rsa=\"http://www.w3.org/ns/auth/rsa#\" xmlns:rss=\"http://web.resource.org/rss/1.0/\" xmlns:sioc=\"http://rdfs.org/sioc/ns#\" xmlns:v=\"http://www.w3.org/2006/vcard/ns#\" xmlns:wot=\"http://xmlns.com/wot/0.1/\" xmlns:xhv=\"http://www.w3.org/1999/xhtml/vocab#\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema#\">Birbeck</span>"^^rdf:XMLLiteral;
    :surname "Birbeck" .
 
 <http://rdfa.info/test-suite/test-cases/rdfa1.1/html4/0295.html#this> a dct:Agent;
@@ -199,7 +200,7 @@ whitespace     preserved
 
 <http://rdfa.info/test-suite/test-cases/rdfa1.1/html4/res> rdf:value ("Bar"),  ("Bar") .
 
-<http://sw-app.org/img/mic_2006_03.jpg> xhv:alternate <http://rdfa.info/test-suite/test-cases/rdfa1.1/html4/0295.html#b>;
+<http://sw-app.org/img/mic_2006_03.jpg> xhv:alternate <http://rdfa.info/test-suite/test-cases/rdfa1.1/html4/0295.html>;
    :depicts <http://sw-app.org/mic.xhtml#i> .
 
 <http://sw-app.org/mic.xhtml#photo> :depicts <http://sw-app.org/mic.xhtml#i> .
@@ -222,425 +223,10 @@ whitespace     preserved
    :knows <http://www.example.org/#somebody>;
    :name "Dan Brickley" .
 
-<http://rdfa.info/test-suite/test-cases/rdfa1.1/html4/0295.html#b> dct:title """
-    
-      Test Suite
-      Test Case 0115
-      Test Case 0114
-      RDFa Website
-      Corner Case #1
-      Corner Case #2
-      Corner Case #3
-      Corner Case #4
-      Corner Case #5
-    
-      Description: XML entities in the RDFa content
-      
-        >
-        Ben & Co.
-        @
-        @
-      
-      
-		Mark Birbeck
-         added this triple test.
-      
-      
-         Check to see if parsers get confused when "" is
-         interpreted as NULL in some chaining cases.
-         Ben
-      
-      
-         
-            The
-            Example Website
-            is used in many W3C tutorials.
-         
-      
-      
-	         The
-	         The XHTML Vocabulary Document
-	         is the default prefix for XHTML+RDFa 1.0.
-	      
-    
-	
-		Test Case 0121
-		checks to make sure RDFa processors resolve the empty CURIE correctly.
-		
-			Shane McCarron
-			contributed to this test.
-		
-	
-	
-    
-         This section is contained below the main site.
-      
-      
-        My article
-      
-Blank Nodes are not allowed to be predicate identifiers in RDF:
-Test
-Test
-   
-      This test ensures that single-character prefixes are allowed. 
-      My name is:
-      John Doe 
-   
-    My name is
-      Gregg Kellogg.
-    
-    
-      Manu can be reached via
-      email.
-      He knows Gregg.
-      Who knows Manu.
-    
+<http://rdfa.info/test-suite/test-cases/rdfa1.1/html4/0295.html#b> dct:title "".
 
-    
-      Gregg can be reached via
-      email.
-    
-    
-        Ivan Herman
-    
-    
-        A particular agent
-    
-    
-  
-      Ivan Herman
-  
-  
-      Ivan Herman
-  
-  
-      Ivan Herman
-  
-    
-      
-        A particular agent
-      
-    
-  
-    
-      A particular agent
-    
-  
-  
-    Ivan Herman
-  
-    
-      
-        Ivan Herman
-      
-    
-    
-      
-        Ivan Herman
-      
-    
-    
-      Ivan Herman
-    
-    
-      Ivan Herman
-    
-	
-    This is an XMLLiteral
-    This is a plain literal
-
-  Gregg Kellogg
-  Ruby
-  Kellogg Associates
-  Ruby Gem
-      
-        Mark Birbeck
-      
-	
-	    An OWL Axiom: "xsd:maxExclusive" is a Datatype Property in OWL.
-	
-   
-       Weekend off in Iona: 
-       Oct 21st
-       to Oct 23rd.
-       See FreeTime.Example.org for
-       info on Iona, UK.
-   
-    
-    
-        Ivan Herman
-    
-    
-  
-      Ivan Herman
-  
-    
-  
-      Ivan Herman
-  
-	  
-  	
-      E = mc2: The Most Urgent Problem of Our Time
-	
-    
-  	
-      E = mc2: The Most Urgent Problem of Our Time
-	
-   This document has a title.
-      
-	  Iván
-      
-	  Iván
-  
-    Gregg Kellogg
-  
-  
-    
-  
-  
-    Foo
-  
-  
-    Foo
-  
-  
-    Foo
-    Foo
-  
-  
-    Foo
-    Bar
-  
-  
-    Foo
-    Bar
-    Baz
-  
-  
-    
-      Foo
-      Bar
-    
-  
-  
-    Foo
-  
-  
-    Bar
-  
-  
-    Foo
-    
-      Bar
-    
-  
-  
-    Foo
-    
-      Bar
-    
-  
-  	
-     	
-  	
-  	
-  	  
-  	
-  
-    
-  
-  
-    
-  
-  	
-	    John Doe
-   	
-  	
-	    John Doe
-   	
-      
-         describedby
-         license
-         role
-      
-    
-      The rdfagraph should not generate triples when
-      looking only at the processor graph.
-    
-  	
-  	
-    ελληνικό
-άσπρο   διάστημα
-
-  	
-    
-Ensure that the "_" prefix is ignored.
-Test
-  
-    Vocabulary Prefixes
-    GRDDL
-    MA
-    OWL
-    RDF
-    RDFa
-    RDFS
-    RIF
-    SKOS
-    SKOS-XL
-    WDR
-    VOID
-    WDRS
-    XHV
-    XML
-    XSD
-  
-  
-    Widely Used prefixes
-    CC
-    CTAG
-    DC
-    DCTERMS
-    FOAF
-    GR
-    ICAL
-    OG
-    REV
-    SIOC
-    V
-    VCARD
-    Schema
-  
-  
-    Vocabulary Terms
-    DescribedBy
-    License
-    Role
-  
-  
-    Vocabulary Terms
-    alternate
-    appendix
-    cite
-    bookmark
-    contents
-    chapter
-    copyright
-    first
-    glossary
-    help
-    icon
-    index
-    last
-    license
-    meta
-    next
-    prev
-    previous
-    section
-    start
-    stylesheet
-    subsection
-    top
-    up
-    p3pv1
-  
-	
-    This is
-an XMLLiteral
-
-   This photo was taken by Mark Birbeck.
-   
-   
-   
-  
-     Ivan Herman
-  
-  
-     Ivan Herman
-  
-  
-     
-  
-   
-   
-   
-  18 March 2012
-  midnight
-  18 March 2012 at midnight
-  2012-03-18Z
-  00:00:00Z
-  2012-03-18T00:00:00Z
-  18 March 2012
-  18 March 2012 at midnight
-  2011 years 6 months 28 days
-  Two Thousand Twelve
-  March, Two Thousand Twelve
-   2012-03-18Z
-   2012-03-18Z
-  
-    Non matching lexical value with language.
-  
-  
-    @value overrides @content in the 'data' element.
-  
-  18 March 2012 at midnight in San Francisco
-  
-  @href becomes subject when @property and @content are present
-  ignored
-  @href becomes subject when @property and @datatype are present
-  value
-  @href as subject overridden by @about
-  ignored
-  @about overriding @href as subject is used as parent resource
-  
-    value two
-  
-  Testing the ':' character usage in a CURIE
-  
-     Test
-  
-  None of these triples should be generated in RDFa 1.0.
-  
-    Vocabulary Prefixes
-    GRDDL
-    MA
-    OWL
-    RDF
-    RDFa
-    RDFS
-    RIF
-    SKOS
-    SKOS-XL
-    WDR
-    VOID
-    WDRS
-    XHV
-    XML
-    XSD
-  
-  
-    Widely Used prefixes
-    CC
-    CTAG
-    DC
-    DCTERMS
-    FOAF
-    GR
-    ICAL
-    OG
-    REV
-    SIOC
-    V
-    VCARD
-    Schema
-  
-  
-    Vocabulary Terms
-    DescribedBy
-  
-
-""",
-     "rdfagraph";
+<http://rdfa.info/test-suite/test-cases/rdfa1.1/html4/0295.html>
+   dct:title "rdfagraph";
    ctag: "CTAG";
    cc: "CC";
    cc:attributionURL <http://rdfa.info/>;
@@ -652,13 +238,12 @@ an XMLLiteral
    og: "OG";
    dct: "DC",
      "DCTERMS";
-   dct:contributor "Mark Birbeck",
-     "Shane McCarron";
+   dct:contributor "Mark Birbeck";
    dct:language "Ruby";
    gr: "GR";
    rev: "REV";
    rdfatest:cornerCase1 <http://rdfa.info/test-suite/test-cases/rdfa1.1/html4/>;
-   rdfatest:cornerCase2 <http://example.org/foo/..>;
+   rdfatest:cornerCase2 <http://example.org/>;
    rdfatest:cornerCase3 <http://rdfa.info/test-suite/test-cases/rdfa1.1/html4/...>;
    rdfatest:cornerCase4 <http://rdfa.info/test-suite/test-cases/rdfa1.1/html4/0295.html?foo=bar../baz>;
    rdfatest:cornerCase5 <http://rdfa.info/test-suite/test-cases/.../.htaccess>;
@@ -674,21 +259,17 @@ an XMLLiteral
      "2012-03-18T00:00:00Z"^^xsd:dateTime,
      " 2012-03-18Z"^^xsd:dateTime,
      "2012-03-18T00:00:00-08:00"^^xsd:dateTime,
-     "veni, vidi, vici",
      "2012-03-18T00:00:00Z"^^xsd:date,
      " 2012-03-18Z",
      "2012-03-18Z"^^xsd:date,
      "D-Day"@en,
+	 "I came, I saw, I conquered"@lat,
      "";
    xhv: "XHV";
    xhv:index <http://rdfa.info/test-suite/#>;
-   xhv:license xmlzzz:license,
-     <http://creativecommons.org/licenses/by-nc-sa/2.0/>,
-     "License",
-     "license";
+   xhv:license xmlzzz:license, "License", "license";
    xhv:next <http://rdfa.info/test-suite/test-cases/rdfa1.1/html4/0115.html>;
-   xhv:role "Role",
-     xmlzzz:role;
+   xhv:role "Role";
    xhv:up <http://rdfa.info/test-suite/test-cases/rdfa1.1/html4/>;
    rdfs: "RDFS";
    xsd: "XSD";

--- a/test-suite/test-cases/rdfa1.1/html5-invalid/0295.html
+++ b/test-suite/test-cases/rdfa1.1/html5-invalid/0295.html
@@ -450,11 +450,11 @@ resource="[_:b]">knows</span>
          <p about="">This is <span property="dc:title">Test 0109</span>.</p>
       </div>
     <div rel="xhv:next">
-      <div rel="xhv:next" />
+      <img rel="xhv:next" />
     </div>
     <div rel="xhv:next">
       <div rel="xhv:next">
-        <div rel="xhv:next" />
+        <img rel="xhv:next" />
       </div>
     </div>
   	  <p>
@@ -506,14 +506,14 @@ whitespace     preserved
 	         is the default prefix for XHTML+RDFa 1.0.
 	      </p>
     <div>
-	<p about="http://example.org/">
+	<div about="http://example.org/">
 		<span about="[]" property="dc:title">Test Case 0121</span>
 		checks to make sure RDFa processors resolve the empty CURIE correctly.
 		<p resource="[]">
 			<span property="dc:contributor">Shane McCarron</span>
 			contributed to this test.
 		</p>
-	</p>
+	</div>
 	</div>
     <p about="http://example.org/section1.html">
          This section is contained below <span rel="up" resource="[]">the main site</span>.
@@ -842,7 +842,7 @@ an XMLLiteral</p>
     Non matching lexical value with language.
   </time>
   <data property="rdf:value" lang="lat" value="veni, vidi, vici" content="I came, I saw, I conquered">
-    @value overrides @content in the 'data' element.
+    @value does not override @content in the 'data' element.
   </data>
   <time property="rdf:value" datetime="2012-03-18T00:00:00-08:00">18 March 2012 at midnight in San Francisco</time>
   <object property="rdf:value" data="http://example.com/"></object>

--- a/test-suite/test-cases/rdfa1.1/html5/0279.sparql
+++ b/test-suite/test-cases/rdfa1.1/html5/0279.sparql
@@ -2,5 +2,5 @@ PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 ASK WHERE {
-  [ rdf:value "2012-03-18T00:00:00Z"^^xsd:date ] .
+  <http://rdfa.info/test-suite/test-cases/rdfa1.1/html5/0279.html> rdf:value "2012-03-18T00:00:00Z"^^xsd:date .
 }

--- a/test-suite/test-cases/rdfa1.1/html5/0279.ttl
+++ b/test-suite/test-cases/rdfa1.1/html5/0279.ttl
@@ -1,4 +1,4 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-[ rdf:value "2012-03-18T00:00:00Z"^^xsd:date ] .
+<<http://rdfa.info/test-suite/test-cases/rdfa1.1/html5/0279.html>> rdf:value "2012-03-18T00:00:00Z"^^xsd:date .

--- a/test-suite/test-cases/rdfa1.1/html5/0279.ttl
+++ b/test-suite/test-cases/rdfa1.1/html5/0279.ttl
@@ -1,4 +1,4 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<<http://rdfa.info/test-suite/test-cases/rdfa1.1/html5/0279.html>> rdf:value "2012-03-18T00:00:00Z"^^xsd:date .
+<http://rdfa.info/test-suite/test-cases/rdfa1.1/html5/0279.html> rdf:value "2012-03-18T00:00:00Z"^^xsd:date .

--- a/test-suite/test-cases/rdfa1.1/html5/0281.sparql
+++ b/test-suite/test-cases/rdfa1.1/html5/0281.sparql
@@ -2,5 +2,5 @@ PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 ASK WHERE {
-  [ rdf:value "2012"^^xsd:gYear ] .
+  <http://rdfa.info/test-suite/test-cases/rdfa1.1/html5/0281.html> rdf:value "2012"^^xsd:gYear .
 }

--- a/test-suite/test-cases/rdfa1.1/html5/0281.ttl
+++ b/test-suite/test-cases/rdfa1.1/html5/0281.ttl
@@ -1,4 +1,4 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-[ rdf:value "2012"^^xsd:gYear ] .
+<<http://rdfa.info/test-suite/test-cases/rdfa1.1/html5/0284.html>> rdf:value "2012"^^xsd:gYear .

--- a/test-suite/test-cases/rdfa1.1/html5/0281.ttl
+++ b/test-suite/test-cases/rdfa1.1/html5/0281.ttl
@@ -1,4 +1,4 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<<http://rdfa.info/test-suite/test-cases/rdfa1.1/html5/0284.html>> rdf:value "2012"^^xsd:gYear .
+<http://rdfa.info/test-suite/test-cases/rdfa1.1/html5/0281.html> rdf:value "2012"^^xsd:gYear .

--- a/test-suite/test-cases/rdfa1.1/html5/0282.sparql
+++ b/test-suite/test-cases/rdfa1.1/html5/0282.sparql
@@ -2,5 +2,5 @@ PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 ASK WHERE {
-  [ rdf:value "2012-03"^^xsd:gYearMonth ] .
+  <http://rdfa.info/test-suite/test-cases/rdfa1.1/html5/0282.html> rdf:value "2012-03"^^xsd:gYearMonth .
 }

--- a/test-suite/test-cases/rdfa1.1/html5/0282.ttl
+++ b/test-suite/test-cases/rdfa1.1/html5/0282.ttl
@@ -1,4 +1,4 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<<http://rdfa.info/test-suite/test-cases/rdfa1.1/html5/0282.html>> rdf:value "2012-03"^^xsd:gYearMonth .
+<http://rdfa.info/test-suite/test-cases/rdfa1.1/html5/0282.html> rdf:value "2012-03"^^xsd:gYearMonth .

--- a/test-suite/test-cases/rdfa1.1/html5/0282.ttl
+++ b/test-suite/test-cases/rdfa1.1/html5/0282.ttl
@@ -1,4 +1,4 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-[ rdf:value "2012-03"^^xsd:gYearMonth ] .
+<<http://rdfa.info/test-suite/test-cases/rdfa1.1/html5/0282.html>> rdf:value "2012-03"^^xsd:gYearMonth .

--- a/test-suite/test-cases/rdfa1.1/html5/0284.sparql
+++ b/test-suite/test-cases/rdfa1.1/html5/0284.sparql
@@ -2,5 +2,5 @@ PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 ASK WHERE {
-  [ rdf:value " 2012-03-18"^^xsd:dateTime ] .
+  <http://rdfa.info/test-suite/test-cases/rdfa1.1/html5/0284.html> rdf:value " 2012-03-18"^^xsd:dateTime .
 }

--- a/test-suite/test-cases/rdfa1.1/html5/0284.ttl
+++ b/test-suite/test-cases/rdfa1.1/html5/0284.ttl
@@ -1,4 +1,4 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<<http://rdfa.info/test-suite/test-cases/rdfa1.1/html5/0284.html>> rdf:value " 2012-03-18"^^xsd:dateTime .
+<http://rdfa.info/test-suite/test-cases/rdfa1.1/html5/0284.html> rdf:value " 2012-03-18"^^xsd:dateTime .

--- a/test-suite/test-cases/rdfa1.1/html5/0284.ttl
+++ b/test-suite/test-cases/rdfa1.1/html5/0284.ttl
@@ -1,4 +1,4 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-[ rdf:value " 2012-03-18"^^xsd:dateTime ] .
+<<http://rdfa.info/test-suite/test-cases/rdfa1.1/html5/0284.html>> rdf:value " 2012-03-18"^^xsd:dateTime .

--- a/test-suite/test-cases/rdfa1.1/html5/0325.sparql
+++ b/test-suite/test-cases/rdfa1.1/html5/0325.sparql
@@ -1,7 +1,7 @@
 BASE <http://example.org/>
 PREFIX schema: <http://schema.org/>
 ASK WHERE {
-  #foo schema:refers-to _:p .
-  #bar schema:refers-to _:p .
+  <#foo> schema:refers-to _:p .
+  <#bar> schema:refers-to _:p .
   _:p schema:name "Amanda" .
 }

--- a/test-suite/test-cases/rdfa1.1/svg/0295.svg
+++ b/test-suite/test-cases/rdfa1.1/svg/0295.svg
@@ -450,11 +450,11 @@ resource="[_:b]">knows</span>
          <p about="">This is <span property="dc:title">Test 0109</span>.</p>
       </div>
     <div rel="xhv:next">
-      <div rel="xhv:next" />
+      <img rel="xhv:next" />
     </div>
     <div rel="xhv:next">
       <div rel="xhv:next">
-        <div rel="xhv:next" />
+        <img rel="xhv:next" />
       </div>
     </div>
   	  <p>
@@ -506,14 +506,14 @@ whitespace     preserved
 	         is the default prefix for XHTML+RDFa 1.0.
 	      </p>
     <div>
-	<p about="http://example.org/">
+	<div about="http://example.org/">
 		<span about="[]" property="dc:title">Test Case 0121</span>
 		checks to make sure RDFa processors resolve the empty CURIE correctly.
 		<p resource="[]">
 			<span property="dc:contributor">Shane McCarron</span>
 			contributed to this test.
 		</p>
-	</p>
+	</div>
 	</div>
     <p about="http://example.org/section1.html">
          This section is contained below <span rel="up" resource="[]">the main site</span>.
@@ -842,7 +842,7 @@ an XMLLiteral</p>
     Non matching lexical value with language.
   </time>
   <data property="rdf:value" lang="lat" value="veni, vidi, vici" content="I came, I saw, I conquered">
-    @value overrides @content in the 'data' element.
+    @value does not override @content in the 'data' element.
   </data>
   <time property="rdf:value" datetime="2012-03-18T00:00:00-08:00">18 March 2012 at midnight in San Francisco</time>
   <object property="rdf:value" data="http://example.com/"></object>

--- a/test-suite/test-cases/rdfa1.1/svg/0295.ttl
+++ b/test-suite/test-cases/rdfa1.1/svg/0295.ttl
@@ -13,6 +13,7 @@
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfa: <http://www.w3.org/ns/rdfa#> .
+@prefix rdfatest: <http://rdfa.info/vocabs/rdfa-test#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix rev: <http://purl.org/stuff/rev#> .
 @prefix rif: <http://www.w3.org/2007/rif#> .
@@ -33,16 +34,17 @@
      "value one",
      "value two" .
 
-xmlzzz: dct:title "Test Case 0121";
-   rdf:value "value" .
+xmlzzz: dct:title "Test Case 0121", "Example Website";
+   rdf:value "value" ;
+   dct:contributor "Shane McCarron" .
 
 xmlzzz:example.png a :Image;
    xhv:license <http://creativecommons.org/licenses/by-nc-sa/2.0/> .
 
-xmlzzz:foo <ex:bar> 10;
+xmlzzz:foo xmlzzz:bar 10;
    dct:creator "Mark Birbeck" .
 
-xmlzzz:jd google:fn "John Doe" .
+xmlzzz:jd vcard:fn "John Doe" .
 
 <http://internet-apps.blogspot.com/> dct:creator "Mark Birbeck" .
 
@@ -53,7 +55,7 @@ xmlzzz:jd google:fn "John Doe" .
 
 <http://rdfa.info/test-suite/test-cases/rdfa1.1/svg/0295.svg> a :Document;
    dct:title "Test 0109",
-     "E = mc2: The Most Urgent Problem of Our Time"^^<ex:XMLLiteral>;
+     "E = mc2: The Most Urgent Problem of Our Time"^^xmlzzz:XMLLiteral;
    cc:license <http://creativecommons.org/licenses/by-nc-nd/2.5/>,
      <http://creativecommons.org/licenses/by-nd/3.0/>;
    dct:creator <http://rdfa.info/test-suite/test-cases/rdfa1.1/svg/jane>,
@@ -90,11 +92,10 @@ xmlzzz:jd google:fn "John Doe" .
      <http://creativecommons.org/licenses/by-nc-sa/2.0/>,
      <http://creativecommons.org/licenses/by-nd/3.0/>;
    xhv:meta xmlzzz:meta;
-   xhv:next [ xhv:next <http://rdfa.info/test-suite/test-cases/rdfa1.1/svg/0295.svg#a>,
-       xmlzzz:node,  [ xhv:next []],
-       <http://rdfa.info/test-suite/test-cases/rdfa1.1/svg/0295.svg#b>],
-     <http://rdfa.info/test-suite/test-cases/rdfa1.1/svg/0070.svg>,
-     xmlzzz:next;
+   xhv:next <http://rdfa.info/test-suite/test-cases/rdfa1.1/svg/0070.svg>,
+     [ xhv:next [] ],
+	 [],
+	 xmlzzz:next;
    xhv:p3pv1 xmlzzz:p3pv1;
    xhv:prev xmlzzz:prev,
      <http://rdfa.info/test-suite/test-cases/rdfa1.1/svg/0069.svg>;
@@ -114,21 +115,21 @@ xmlzzz:jd google:fn "John Doe" .
    ];
    :topic "John Doe" .
 
-<http://rdfa.info/test-suite/test-cases/rdfa1.1/svg/0295.svg#event1> a <cal:Vevent>;
-   <cal:dtend> "2006-10-23"^^xsd:date;
-   <cal:dtstart> "2006-10-21"^^xsd:date;
-   <cal:location> "Iona, UK";
-   <cal:summary> "Weekend off in Iona";
-   <cal:url> <http://freetime.example.org/> .
+<http://rdfa.info/test-suite/test-cases/rdfa1.1/svg/0295.svg#event1> a cal:Vevent;
+   cal:dtend "2006-10-23"^^xsd:date;
+   cal:dtstart "2006-10-21"^^xsd:date;
+   cal:location "Iona, UK";
+   cal:summary "Weekend off in Iona";
+   cal:url <http://freetime.example.org/> .
 
-<http://rdfa.info/test-suite/test-cases/rdfa1.1/svg/0295.svg#interfenestration> <example:size> [
-     <example:unit> "character";
+<http://rdfa.info/test-suite/test-cases/rdfa1.1/svg/0295.svg#interfenestration> xmlzzz:size [
+     xmlzzz:unit "character";
      rdf:value "17"
    ] .
 
 <http://rdfa.info/test-suite/test-cases/rdfa1.1/svg/0295.svg#mark> a :Person;
    :firstName "Mark";
-   :name "<span property=\"foaf:firstName\">Mark</span> <span property=\"foaf:surname\">Birbeck</span><span xmlns=\"http://www.w3.org/1999/xhtml\" property=\"foaf:firstName\">Mark</span><span xmlns=\"http://www.w3.org/1999/xhtml\" property=\"foaf:surname\">Birbeck</span>"^^rdf:XMLLiteral;
+   :name "<span property=\"foaf:firstName\" xmlns:air=\"http://www.daml.org/2001/10/html/airport-ont#\" xmlns:bio=\"http://vocab.org/bio/0.1/\" xmlns:cal=\"http://www.w3.org/2002/12/cal/icaltzd#\" xmlns:cc=\"http://creativecommons.org/ns#\" xmlns:cert=\"http://www.w3.org/ns/auth/cert#\" xmlns:contact=\"http://www.w3.org/2000/10/swap/pim/contact#\" xmlns:dc=\"http://purl.org/dc/terms/\" xmlns:dct=\"http://purl.org/dc/terms/\" xmlns:earl=\"http://www.w3.org/ns/earl#\" xmlns:ex=\"http://example.org/\" xmlns:example=\"http://example.org/\" xmlns:foaf=\"http://xmlns.com/foaf/0.1/\" xmlns:google=\"http://rdf.data-vocabulary.org/#\" xmlns:ical=\"http://www.w3.org/2002/12/cal/icaltzd#\" xmlns:openid=\"http://xmlns.openid.net/auth#\" xmlns:owl=\"http://www.w3.org/2002/07/owl#\" xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\" xmlns:rdfatest=\"http://rdfa.info/vocabs/rdfa-test#\" xmlns:rdfs=\"http://www.w3.org/2000/01/rdf-schema#\" xmlns:rel=\"http://vocab.org/relationship/\" xmlns:rsa=\"http://www.w3.org/ns/auth/rsa#\" xmlns:rss=\"http://web.resource.org/rss/1.0/\" xmlns:sioc=\"http://rdfs.org/sioc/ns#\" xmlns:v=\"http://www.w3.org/2006/vcard/ns#\" xmlns:wot=\"http://xmlns.com/wot/0.1/\" xmlns:xhv=\"http://www.w3.org/1999/xhtml/vocab#\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema#\">Mark</span> <span property=\"foaf:surname\" xmlns:air=\"http://www.daml.org/2001/10/html/airport-ont#\" xmlns:bio=\"http://vocab.org/bio/0.1/\" xmlns:cal=\"http://www.w3.org/2002/12/cal/icaltzd#\" xmlns:cc=\"http://creativecommons.org/ns#\" xmlns:cert=\"http://www.w3.org/ns/auth/cert#\" xmlns:contact=\"http://www.w3.org/2000/10/swap/pim/contact#\" xmlns:dc=\"http://purl.org/dc/terms/\" xmlns:dct=\"http://purl.org/dc/terms/\" xmlns:earl=\"http://www.w3.org/ns/earl#\" xmlns:ex=\"http://example.org/\" xmlns:example=\"http://example.org/\" xmlns:foaf=\"http://xmlns.com/foaf/0.1/\" xmlns:google=\"http://rdf.data-vocabulary.org/#\" xmlns:ical=\"http://www.w3.org/2002/12/cal/icaltzd#\" xmlns:openid=\"http://xmlns.openid.net/auth#\" xmlns:owl=\"http://www.w3.org/2002/07/owl#\" xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\" xmlns:rdfatest=\"http://rdfa.info/vocabs/rdfa-test#\" xmlns:rdfs=\"http://www.w3.org/2000/01/rdf-schema#\" xmlns:rel=\"http://vocab.org/relationship/\" xmlns:rsa=\"http://www.w3.org/ns/auth/rsa#\" xmlns:rss=\"http://web.resource.org/rss/1.0/\" xmlns:sioc=\"http://rdfs.org/sioc/ns#\" xmlns:v=\"http://www.w3.org/2006/vcard/ns#\" xmlns:wot=\"http://xmlns.com/wot/0.1/\" xmlns:xhv=\"http://www.w3.org/1999/xhtml/vocab#\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema#\">Birbeck</span>"^^rdf:XMLLiteral;
    :surname "Birbeck" .
 
 <http://rdfa.info/test-suite/test-cases/rdfa1.1/svg/0295.svg#this> a dct:Agent;
@@ -138,7 +139,7 @@ xmlzzz:jd google:fn "John Doe" .
 
 <http://rdfa.info/test-suite/test-cases/rdfa1.1/svg/faq> dct:title "Example FAQ" .
 
-<http://www.cwi.nl/~steven/> <example:likes> """
+<http://www.cwi.nl/~steven/> xmlzzz:likes """
     We put thirty spokes together and call it a wheel;
     But it is on the space where there is nothing that the usefulness of the wheel depends.
     We turn clay to make a vessel;
@@ -149,8 +150,8 @@ xmlzzz:jd google:fn "John Doe" .
 
     Lao Tzu: Tao Te Ching""" .
 
-<http://www.example.org> <ex:plainlit> "This is a plain literal";
-   <ex:xmllit> "This is an XMLLiteral"^^rdf:XMLLiteral,
+<http://www.example.org> xmlzzz:plainlit "This is a plain literal";
+   xmlzzz:xmllit "This is an XMLLiteral"^^rdf:XMLLiteral,
      """This is
 an XMLLiteral"""^^rdf:XMLLiteral;
    ex:column:test "Test" .
@@ -159,7 +160,7 @@ ex: dct:title "E = mc2: The Most Urgent Problem of Our Time" .
 
 <http://www.example.org/#article> a sioc:Post,
      :Document;
-   <dct:title> "My article" .
+   dct:title "My article" .
 
 <http://www.example.org/#ben> a :Person;
    :knows [ :name [ a :Person],  [ a :Person]],
@@ -178,7 +179,7 @@ xsd:maxExclusive a owl:DatatypeProperty .
 
 <http://www.w3.org/Person/Ivan#me> owl:sameAs <http://www.ivan-herman.net/foaf#me> .
 
-xmlzzz:node <ex:property> """not an XML Literal,
+xmlzzz:node xmlzzz:property """not an XML Literal,
 whitespace     preserved
 """,
      """ελληνικό
@@ -198,7 +199,7 @@ whitespace     preserved
 
 <http://rdfa.info/test-suite/test-cases/rdfa1.1/svg/res> rdf:value ("Bar"),  ("Bar") .
 
-<http://sw-app.org/img/mic_2006_03.jpg> xhv:alternate <http://rdfa.info/test-suite/test-cases/rdfa1.1/svg/0295.svg#b>;
+<http://sw-app.org/img/mic_2006_03.jpg> xhv:alternate <http://rdfa.info/test-suite/test-cases/rdfa1.1/svg/0295.svg>;
    :depicts <http://sw-app.org/mic.xhtml#i> .
 
 <http://sw-app.org/mic.xhtml#photo> :depicts <http://sw-app.org/mic.xhtml#i> .
@@ -221,430 +222,14 @@ whitespace     preserved
    :knows <http://www.example.org/#somebody>;
    :name "Dan Brickley" .
 
-<http://rdfa.info/test-suite/test-cases/rdfa1.1/svg/0295.svg#b> dct:title """
-    
-      Test Suite
-      Test Case 0115
-      Test Case 0114
-      RDFa Website
-      Corner Case #1
-      Corner Case #2
-      Corner Case #3
-      Corner Case #4
-      Corner Case #5
-    
-      Description: XML entities in the RDFa content
-      
-        >
-        Ben & Co.
-        @
-        @
-      
-      
-		Mark Birbeck
-         added this triple test.
-      
-      
-         Check to see if parsers get confused when "" is
-         interpreted as NULL in some chaining cases.
-         Ben
-      
-      
-         
-            The
-            Example Website
-            is used in many W3C tutorials.
-         
-      
-      
-	         The
-	         The XHTML Vocabulary Document
-	         is the default prefix for XHTML+RDFa 1.0.
-	      
-    
-	
-		Test Case 0121
-		checks to make sure RDFa processors resolve the empty CURIE correctly.
-		
-			Shane McCarron
-			contributed to this test.
-		
-	
-	
-    
-         This section is contained below the main site.
-      
-      
-        My article
-      
-Blank Nodes are not allowed to be predicate identifiers in RDF:
-Test
-Test
-   
-      This test ensures that single-character prefixes are allowed. 
-      My name is:
-      John Doe 
-   
-    My name is
-      Gregg Kellogg.
-    
-    
-      Manu can be reached via
-      email.
-      He knows Gregg.
-      Who knows Manu.
-    
+<http://rdfa.info/test-suite/test-cases/rdfa1.1/svg/0295.svg#b> dct:title "".
 
-    
-      Gregg can be reached via
-      email.
-    
-    
-        Ivan Herman
-    
-    
-        A particular agent
-    
-    
-  
-      Ivan Herman
-  
-  
-      Ivan Herman
-  
-  
-      Ivan Herman
-  
-    
-      
-        A particular agent
-      
-    
-  
-    
-      A particular agent
-    
-  
-  
-    Ivan Herman
-  
-    
-      
-        Ivan Herman
-      
-    
-    
-      
-        Ivan Herman
-      
-    
-    
-      Ivan Herman
-    
-    
-      Ivan Herman
-    
-	
-    This is an XMLLiteral
-    This is a plain literal
-
-  Gregg Kellogg
-  Ruby
-  Kellogg Associates
-  Ruby Gem
-      
-        Mark Birbeck
-      
-	
-	    An OWL Axiom: "xsd:maxExclusive" is a Datatype Property in OWL.
-	
-   
-       Weekend off in Iona: 
-       Oct 21st
-       to Oct 23rd.
-       See FreeTime.Example.org for
-       info on Iona, UK.
-   
-    
-    
-        Ivan Herman
-    
-    
-  
-      Ivan Herman
-  
-    
-  
-      Ivan Herman
-  
-	  
-  	
-      E = mc2: The Most Urgent Problem of Our Time
-	
-    
-  	
-      E = mc2: The Most Urgent Problem of Our Time
-	
-   This document has a title.
-      
-	  Iván
-      
-	  Iván
-  
-    Gregg Kellogg
-  
-  
-    
-  
-  
-    Foo
-  
-  
-    Foo
-  
-  
-    Foo
-    Foo
-  
-  
-    Foo
-    Bar
-  
-  
-    Foo
-    Bar
-    Baz
-  
-  
-    
-      Foo
-      Bar
-    
-  
-  
-    Foo
-  
-  
-    Bar
-  
-  
-    Foo
-    
-      Bar
-    
-  
-  
-    Foo
-    
-      Bar
-    
-  
-  	
-     	
-  	
-  	
-  	  
-  	
-  
-    
-  
-  
-    
-  
-  	
-	    John Doe
-   	
-  	
-	    John Doe
-   	
-      
-         describedby
-         license
-         role
-      
-    
-      The rdfagraph should not generate triples when
-      looking only at the processor graph.
-    
-  	
-  	
-    ελληνικό
-άσπρο   διάστημα
-
-  	
-    
-Ensure that the "_" prefix is ignored.
-Test
-  
-    Vocabulary Prefixes
-    GRDDL
-    MA
-    OWL
-    RDF
-    RDFa
-    RDFS
-    RIF
-    SKOS
-    SKOS-XL
-    WDR
-    VOID
-    WDRS
-    XHV
-    XML
-    XSD
-  
-  
-    Widely Used prefixes
-    CC
-    CTAG
-    DC
-    DCTERMS
-    FOAF
-    GR
-    ICAL
-    OG
-    REV
-    SIOC
-    V
-    VCARD
-    Schema
-  
-  
-    Vocabulary Terms
-    DescribedBy
-    License
-    Role
-  
-  
-    Vocabulary Terms
-    alternate
-    appendix
-    cite
-    bookmark
-    contents
-    chapter
-    copyright
-    first
-    glossary
-    help
-    icon
-    index
-    last
-    license
-    meta
-    next
-    prev
-    previous
-    section
-    start
-    stylesheet
-    subsection
-    top
-    up
-    p3pv1
-  
-	
-    This is
-an XMLLiteral
-
-   This photo was taken by Mark Birbeck.
-   
-   
-   
-  
-     Ivan Herman
-  
-  
-     Ivan Herman
-  
-  
-     
-  
-   
-   
-   
-  18 March 2012
-  midnight
-  18 March 2012 at midnight
-  2012-03-18Z
-  00:00:00Z
-  2012-03-18T00:00:00Z
-  18 March 2012
-  18 March 2012 at midnight
-  2011 years 6 months 28 days
-  Two Thousand Twelve
-  March, Two Thousand Twelve
-   2012-03-18Z
-   2012-03-18Z
-  
-    Non matching lexical value with language.
-  
-  
-    @value overrides @content in the 'data' element.
-  
-  18 March 2012 at midnight in San Francisco
-  
-  @href becomes subject when @property and @content are present
-  ignored
-  @href becomes subject when @property and @datatype are present
-  value
-  @href as subject overridden by @about
-  ignored
-  @about overriding @href as subject is used as parent resource
-  
-    value two
-  
-  Testing the ':' character usage in a CURIE
-  
-     Test
-  
-  None of these triples should be generated in RDFa 1.0.
-  
-    Vocabulary Prefixes
-    GRDDL
-    MA
-    OWL
-    RDF
-    RDFa
-    RDFS
-    RIF
-    SKOS
-    SKOS-XL
-    WDR
-    VOID
-    WDRS
-    XHV
-    XML
-    XSD
-  
-  
-    Widely Used prefixes
-    CC
-    CTAG
-    DC
-    DCTERMS
-    FOAF
-    GR
-    ICAL
-    OG
-    REV
-    SIOC
-    V
-    VCARD
-    Schema
-  
-  
-    Vocabulary Terms
-    DescribedBy
-  
-
-""",
-     "Example Website",
-     "rdfagraph";
-   <ex:entity1> ">";
-   <ex:entity2> "Ben & Co.";
-   <ex:entity3> "@";
-   <ex:entity4> "@";
+<http://rdfa.info/test-suite/test-cases/rdfa1.1/svg/0295.svg>
+   dct:title "rdfagraph";
+   xmlzzz:entity1 ">";
+   xmlzzz:entity2 "Ben & Co.";
+   xmlzzz:entity3 "@";
+   xmlzzz:entity4 "@";
    ctag: "CTAG";
    cc: "CC";
    cc:attributionURL <http://rdfa.info/>;
@@ -652,12 +237,11 @@ an XMLLiteral
    og: "OG";
    dct: "DC",
      "DCTERMS";
-   dct:contributor "Mark Birbeck",
-     "Shane McCarron";
+   dct:contributor "Mark Birbeck";
    dct:language "Ruby";
    gr: "GR";
    rev: "REV";
-   google: "V";
+   vcard: "V";
    void: "VOID";
    sioc: "SIOC";
    schema: "Schema";
@@ -670,21 +254,17 @@ an XMLLiteral
      "2012-03-18T00:00:00Z"^^xsd:dateTime,
      " 2012-03-18Z"^^xsd:dateTime,
      "2012-03-18T00:00:00-08:00"^^xsd:dateTime,
-     "veni, vidi, vici",
      "2012-03-18T00:00:00Z"^^xsd:date,
      " 2012-03-18Z",
      "2012-03-18Z"^^xsd:date,
      "D-Day"@en,
+	 "I came, I saw, I conquered"@lat,
      "";
    xhv: "XHV";
    xhv:index <http://rdfa.info/test-suite/#>;
-   xhv:license xmlzzz:license,
-     <http://creativecommons.org/licenses/by-nc-sa/2.0/>,
-     "License",
-     "license";
+   xhv:license "License", "license";
    xhv:next <http://rdfa.info/test-suite/test-cases/rdfa1.1/svg/0115.svg>;
-   xhv:role "Role",
-     xmlzzz:role;
+   xhv:role "Role";
    xhv:up <http://rdfa.info/test-suite/test-cases/rdfa1.1/svg/>;
    rdfs: "RDFS";
    xsd: "XSD";
@@ -710,11 +290,11 @@ an XMLLiteral
      :name "John Doe"
    ],
      <http://www.example.org/#me>;
-   <rdfatest:cornerCase1> <http://rdfa.info/test-suite/test-cases/rdfa1.1/svg/>;
-   <rdfatest:cornerCase2> <http://example.org/foo/..>;
-   <rdfatest:cornerCase3> <http://rdfa.info/test-suite/test-cases/rdfa1.1/svg/...>;
-   <rdfatest:cornerCase4> <http://rdfa.info/test-suite/test-cases/rdfa1.1/svg/0295.svg?foo=bar../baz>;
-   <rdfatest:cornerCase5> <http://rdfa.info/test-suite/test-cases/.../.htaccess> .
+   rdfatest:cornerCase1 <http://rdfa.info/test-suite/test-cases/rdfa1.1/svg/>;
+   rdfatest:cornerCase2 <http://example.org/>;
+   rdfatest:cornerCase3 <http://rdfa.info/test-suite/test-cases/rdfa1.1/svg/...>;
+   rdfatest:cornerCase4 <http://rdfa.info/test-suite/test-cases/rdfa1.1/svg/0295.svg?foo=bar../baz>;
+   rdfatest:cornerCase5 <http://rdfa.info/test-suite/test-cases/.../.htaccess>.
 
 <http://www.example.org/#fabien> :name "Fabien Gandon" .
 

--- a/test-suite/test-cases/rdfa1.1/svg/0304.sparql
+++ b/test-suite/test-cases/rdfa1.1/svg/0304.sparql
@@ -1,5 +1,4 @@
 ASK WHERE {
-	<http://example.net/> <http://purl.org/dc/terms/title> "Test 0304" .
 	<http://example.net/> <http://purl.org/dc/terms/description> "A yellow rectangle with sharp corners." .
 }
 

--- a/test-suite/test-cases/rdfa1.1/svg/0304.ttl
+++ b/test-suite/test-cases/rdfa1.1/svg/0304.ttl
@@ -1,5 +1,4 @@
 @prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<http://example.net/> dcterms:title "Test 0304";
-   dcterms:description "A yellow rectangle with sharp corners." .
+<http://example.net/> dcterms:description "A yellow rectangle with sharp corners." .

--- a/test-suite/test-cases/rdfa1.1/xhtml1/0121.xhtml
+++ b/test-suite/test-cases/rdfa1.1/xhtml1/0121.xhtml
@@ -6,14 +6,14 @@
    </head>
    <body>
     <div>
-	<p about="http://example.org/">
+	<div about="http://example.org/">
 		<span about="[]" property="dc:title">Test Case 0121</span>
 		checks to make sure RDFa processors resolve the empty CURIE correctly.
 		<p resource="[]">
 			<span property="dc:contributor">Shane McCarron</span>
 			contributed to this test.
 		</p>
-	</p>
+	</div>
 	</div>
    </body>
 

--- a/test-suite/test-cases/rdfa1.1/xhtml1/0260.sparql
+++ b/test-suite/test-cases/rdfa1.1/xhtml1/0260.sparql
@@ -1,7 +1,7 @@
 PREFIX xhv: <http://www.w3.org/1999/xhtml/vocab#>
 
 ASK WHERE {
-  [
+  <http://rdfa.info/test-suite/test-cases/rdfa1.1/xhtml1/0260.xhtml>
     # Vocabulary Terms
     xhv:alternate "alternate";
     xhv:appendix "appendix";
@@ -30,5 +30,5 @@ ASK WHERE {
     
     # Other terms
     xhv:p3pv1 "p3pv1"
-  ]
+  .
 }

--- a/test-suite/test-cases/rdfa1.1/xhtml1/0260.ttl
+++ b/test-suite/test-cases/rdfa1.1/xhtml1/0260.ttl
@@ -1,7 +1,7 @@
 @prefix xhv: <http://www.w3.org/1999/xhtml/vocab#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-[
+<http://rdfa.info/test-suite/test-cases/rdfa1.1/xhtml1/0260.xhtml>
   # Vocabulary Terms
   xhv:alternate "alternate";
   xhv:appendix "appendix";
@@ -30,4 +30,4 @@
 
   # Other terms
   xhv:p3pv1 "p3pv1"
-] .
+.

--- a/test-suite/test-cases/rdfa1.1/xhtml1/0295.ttl
+++ b/test-suite/test-cases/rdfa1.1/xhtml1/0295.ttl
@@ -35,7 +35,8 @@
 
 xmlzzz: dct:title "Test Case 0121",
      "Example Website";
-   rdf:value "value" .
+   rdf:value "value" ;
+   dct:contributor "Shane McCarron" .
 
 xmlzzz:example.png a :Image;
    xhv:license <http://creativecommons.org/licenses/by-nc-sa/2.0/> .
@@ -49,8 +50,31 @@ xmlzzz:jd vcard:fn "John Doe" .
 
 <http://rdfa.info/test-suite/test-cases/rdfa1.1/xhtml1/0067.xhtml> dct:title "Test 0067" .
 
-<http://rdfa.info/test-suite/test-cases/rdfa1.1/xhtml1/0077.xhtml> xhv:license xmlzzz:license;
-   xhv:role xmlzzz:role .
+<http://rdfa.info/test-suite/test-cases/rdfa1.1/xhtml1/0077.xhtml>
+   xhv:alternate xmlzzz:alternate ;
+   xhv:appendix xmlzzz:appendix ;
+   xhv:bookmark xmlzzz:bookmark ;
+   xhv:cite xmlzzz:cite ;
+   xhv:chapter xmlzzz:chapter ;
+   xhv:contents xmlzzz:contents ;
+   xhv:copyright xmlzzz:copyright ;
+   xhv:glossary xmlzzz:glossary ;
+   xhv:help xmlzzz:help ;
+   xhv:icon xmlzzz:icon ;
+   xhv:index xmlzzz:index ;
+   xhv:first xmlzzz:first ;
+   xhv:last xmlzzz:last ;
+   xhv:license xmlzzz:license ;
+   xhv:meta xmlzzz:meta ;
+   xhv:next xmlzzz:next ;
+   xhv:p3pv1 xmlzzz:p3pv1 ;
+   xhv:prev xmlzzz:prev ;
+   xhv:role xmlzzz:role ;
+   xhv:section xmlzzz:section ;
+   xhv:subsection xmlzzz:subsection ;
+   xhv:start xmlzzz:start ;
+   xhv:stylesheet xmlzzz:stylesheet ;
+   xhv:up xmlzzz:up .
 
 <http://rdfa.info/test-suite/test-cases/rdfa1.1/xhtml1/0295.xhtml> a :Document;
    dct:title "E = mc2: The Most Urgent Problem of Our Time"^^xmlzzz:XMLLiteral,
@@ -91,10 +115,10 @@ xmlzzz:jd vcard:fn "John Doe" .
      <http://creativecommons.org/licenses/by-nc-sa/2.0/>,
      <http://creativecommons.org/licenses/by-nd/3.0/>;
    xhv:meta xmlzzz:meta;
-   xhv:next <http://rdfa.info/test-suite/test-cases/rdfa1.1/xhtml1/0070.xhtml>,  [ xhv:next xmlzzz:node,
-       <http://rdfa.info/test-suite/test-cases/rdfa1.1/xhtml1/0295.xhtml#a>,  [ xhv:next []],
-       <http://rdfa.info/test-suite/test-cases/rdfa1.1/xhtml1/0295.xhtml#b>],
-     xmlzzz:next;
+   xhv:next <http://rdfa.info/test-suite/test-cases/rdfa1.1/xhtml1/0070.xhtml>,
+     [ xhv:next [] ],
+	 [],
+	 xmlzzz:next;
    xhv:p3pv1 xmlzzz:p3pv1;
    xhv:prev xmlzzz:prev,
      <http://rdfa.info/test-suite/test-cases/rdfa1.1/xhtml1/0069.xhtml>;
@@ -129,7 +153,7 @@ xmlzzz:jd vcard:fn "John Doe" .
 
 <http://rdfa.info/test-suite/test-cases/rdfa1.1/xhtml1/0295.xhtml#mark> a :Person;
    :firstName "Mark";
-   :name "<span property=\"foaf:firstName\">Mark</span> <span property=\"foaf:surname\">Birbeck</span><span xmlns=\"http://www.w3.org/1999/xhtml\" property=\"foaf:firstName\">Mark</span><span xmlns=\"http://www.w3.org/1999/xhtml\" property=\"foaf:surname\">Birbeck</span>"^^rdf:XMLLiteral;
+   :name "<span property=\"foaf:firstName\" xmlns=\"http://www.w3.org/1999/xhtml\" xmlns:air=\"http://www.daml.org/2001/10/html/airport-ont#\" xmlns:bio=\"http://vocab.org/bio/0.1/\" xmlns:cal=\"http://www.w3.org/2002/12/cal/icaltzd#\" xmlns:cc=\"http://creativecommons.org/ns#\" xmlns:cert=\"http://www.w3.org/ns/auth/cert#\" xmlns:contact=\"http://www.w3.org/2000/10/swap/pim/contact#\" xmlns:dc=\"http://purl.org/dc/terms/\" xmlns:dct=\"http://purl.org/dc/terms/\" xmlns:earl=\"http://www.w3.org/ns/earl#\" xmlns:ex=\"http://example.org/\" xmlns:example=\"http://example.org/\" xmlns:foaf=\"http://xmlns.com/foaf/0.1/\" xmlns:google=\"http://rdf.data-vocabulary.org/#\" xmlns:ical=\"http://www.w3.org/2002/12/cal/icaltzd#\" xmlns:openid=\"http://xmlns.openid.net/auth#\" xmlns:owl=\"http://www.w3.org/2002/07/owl#\" xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\" xmlns:rdfatest=\"http://rdfa.info/vocabs/rdfa-test#\" xmlns:rdfs=\"http://www.w3.org/2000/01/rdf-schema#\" xmlns:rel=\"http://vocab.org/relationship/\" xmlns:rsa=\"http://www.w3.org/ns/auth/rsa#\" xmlns:rss=\"http://web.resource.org/rss/1.0/\" xmlns:sioc=\"http://rdfs.org/sioc/ns#\" xmlns:v=\"http://www.w3.org/2006/vcard/ns#\" xmlns:wot=\"http://xmlns.com/wot/0.1/\" xmlns:xhv=\"http://www.w3.org/1999/xhtml/vocab#\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema#\">Mark</span> <span property=\"foaf:surname\" xmlns=\"http://www.w3.org/1999/xhtml\" xmlns:air=\"http://www.daml.org/2001/10/html/airport-ont#\" xmlns:bio=\"http://vocab.org/bio/0.1/\" xmlns:cal=\"http://www.w3.org/2002/12/cal/icaltzd#\" xmlns:cc=\"http://creativecommons.org/ns#\" xmlns:cert=\"http://www.w3.org/ns/auth/cert#\" xmlns:contact=\"http://www.w3.org/2000/10/swap/pim/contact#\" xmlns:dc=\"http://purl.org/dc/terms/\" xmlns:dct=\"http://purl.org/dc/terms/\" xmlns:earl=\"http://www.w3.org/ns/earl#\" xmlns:ex=\"http://example.org/\" xmlns:example=\"http://example.org/\" xmlns:foaf=\"http://xmlns.com/foaf/0.1/\" xmlns:google=\"http://rdf.data-vocabulary.org/#\" xmlns:ical=\"http://www.w3.org/2002/12/cal/icaltzd#\" xmlns:openid=\"http://xmlns.openid.net/auth#\" xmlns:owl=\"http://www.w3.org/2002/07/owl#\" xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\" xmlns:rdfatest=\"http://rdfa.info/vocabs/rdfa-test#\" xmlns:rdfs=\"http://www.w3.org/2000/01/rdf-schema#\" xmlns:rel=\"http://vocab.org/relationship/\" xmlns:rsa=\"http://www.w3.org/ns/auth/rsa#\" xmlns:rss=\"http://web.resource.org/rss/1.0/\" xmlns:sioc=\"http://rdfs.org/sioc/ns#\" xmlns:v=\"http://www.w3.org/2006/vcard/ns#\" xmlns:wot=\"http://xmlns.com/wot/0.1/\" xmlns:xhv=\"http://www.w3.org/1999/xhtml/vocab#\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema#\">Birbeck</span>"^^rdf:XMLLiteral;
    :surname "Birbeck" .
 
 <http://rdfa.info/test-suite/test-cases/rdfa1.1/xhtml1/0295.xhtml#this> a dct:Agent;
@@ -199,7 +223,7 @@ whitespace     preserved
 
 <http://rdfa.info/test-suite/test-cases/rdfa1.1/xhtml1/res> rdf:value ("Bar"),  ("Bar") .
 
-<http://sw-app.org/img/mic_2006_03.jpg> xhv:alternate <http://rdfa.info/test-suite/test-cases/rdfa1.1/xhtml1/0295.xhtml#b>;
+<http://sw-app.org/img/mic_2006_03.jpg> xhv:alternate <http://rdfa.info/test-suite/test-cases/rdfa1.1/xhtml1/0295.xhtml>;
    :depicts <http://sw-app.org/mic.xhtml#i> .
 
 <http://sw-app.org/mic.xhtml#photo> :depicts <http://sw-app.org/mic.xhtml#i> .
@@ -222,425 +246,10 @@ whitespace     preserved
    :knows <http://www.example.org/#somebody>;
    :name "Dan Brickley" .
 
-<http://rdfa.info/test-suite/test-cases/rdfa1.1/xhtml1/0295.xhtml#b> dct:title """
-    
-      Test Suite
-      Test Case 0115
-      Test Case 0114
-      RDFa Website
-      Corner Case #1
-      Corner Case #2
-      Corner Case #3
-      Corner Case #4
-      Corner Case #5
-    
-      Description: XML entities in the RDFa content
-      
-        >
-        Ben & Co.
-        @
-        @
-      
-      
-		Mark Birbeck
-         added this triple test.
-      
-      
-         Check to see if parsers get confused when "" is
-         interpreted as NULL in some chaining cases.
-         Ben
-      
-      
-         
-            The
-            Example Website
-            is used in many W3C tutorials.
-         
-      
-      
-	         The
-	         The XHTML Vocabulary Document
-	         is the default prefix for XHTML+RDFa 1.0.
-	      
-    
-	
-		Test Case 0121
-		checks to make sure RDFa processors resolve the empty CURIE correctly.
-		
-			Shane McCarron
-			contributed to this test.
-		
-	
-	
-    
-         This section is contained below the main site.
-      
-      
-        My article
-      
-Blank Nodes are not allowed to be predicate identifiers in RDF:
-Test
-Test
-   
-      This test ensures that single-character prefixes are allowed. 
-      My name is:
-      John Doe 
-   
-    My name is
-      Gregg Kellogg.
-    
-    
-      Manu can be reached via
-      email.
-      He knows Gregg.
-      Who knows Manu.
-    
+<http://rdfa.info/test-suite/test-cases/rdfa1.1/xhtml1/0295.xhtml#b> dct:title "" .
 
-    
-      Gregg can be reached via
-      email.
-    
-    
-        Ivan Herman
-    
-    
-        A particular agent
-    
-    
-  
-      Ivan Herman
-  
-  
-      Ivan Herman
-  
-  
-      Ivan Herman
-  
-    
-      
-        A particular agent
-      
-    
-  
-    
-      A particular agent
-    
-  
-  
-    Ivan Herman
-  
-    
-      
-        Ivan Herman
-      
-    
-    
-      
-        Ivan Herman
-      
-    
-    
-      Ivan Herman
-    
-    
-      Ivan Herman
-    
-	
-    This is an XMLLiteral
-    This is a plain literal
-
-  Gregg Kellogg
-  Ruby
-  Kellogg Associates
-  Ruby Gem
-      
-        Mark Birbeck
-      
-	
-	    An OWL Axiom: "xsd:maxExclusive" is a Datatype Property in OWL.
-	
-   
-       Weekend off in Iona: 
-       Oct 21st
-       to Oct 23rd.
-       See FreeTime.Example.org for
-       info on Iona, UK.
-   
-    
-    
-        Ivan Herman
-    
-    
-  
-      Ivan Herman
-  
-    
-  
-      Ivan Herman
-  
-	  
-  	
-      E = mc2: The Most Urgent Problem of Our Time
-	
-    
-  	
-      E = mc2: The Most Urgent Problem of Our Time
-	
-   This document has a title.
-      
-	  Iván
-      
-	  Iván
-  
-    Gregg Kellogg
-  
-  
-    
-  
-  
-    Foo
-  
-  
-    Foo
-  
-  
-    Foo
-    Foo
-  
-  
-    Foo
-    Bar
-  
-  
-    Foo
-    Bar
-    Baz
-  
-  
-    
-      Foo
-      Bar
-    
-  
-  
-    Foo
-  
-  
-    Bar
-  
-  
-    Foo
-    
-      Bar
-    
-  
-  
-    Foo
-    
-      Bar
-    
-  
-  	
-     	
-  	
-  	
-  	  
-  	
-  
-    
-  
-  
-    
-  
-  	
-	    John Doe
-   	
-  	
-	    John Doe
-   	
-      
-         describedby
-         license
-         role
-      
-    
-      The rdfagraph should not generate triples when
-      looking only at the processor graph.
-    
-  	
-  	
-    ελληνικό
-άσπρο   διάστημα
-
-  	
-    
-Ensure that the "_" prefix is ignored.
-Test
-  
-    Vocabulary Prefixes
-    GRDDL
-    MA
-    OWL
-    RDF
-    RDFa
-    RDFS
-    RIF
-    SKOS
-    SKOS-XL
-    WDR
-    VOID
-    WDRS
-    XHV
-    XML
-    XSD
-  
-  
-    Widely Used prefixes
-    CC
-    CTAG
-    DC
-    DCTERMS
-    FOAF
-    GR
-    ICAL
-    OG
-    REV
-    SIOC
-    V
-    VCARD
-    Schema
-  
-  
-    Vocabulary Terms
-    DescribedBy
-    License
-    Role
-  
-  
-    Vocabulary Terms
-    alternate
-    appendix
-    cite
-    bookmark
-    contents
-    chapter
-    copyright
-    first
-    glossary
-    help
-    icon
-    index
-    last
-    license
-    meta
-    next
-    prev
-    previous
-    section
-    start
-    stylesheet
-    subsection
-    top
-    up
-    p3pv1
-  
-	
-    This is
-an XMLLiteral
-
-   This photo was taken by Mark Birbeck.
-   
-   
-   
-  
-     Ivan Herman
-  
-  
-     Ivan Herman
-  
-  
-     
-  
-   
-   
-   
-  18 March 2012
-  midnight
-  18 March 2012 at midnight
-  2012-03-18Z
-  00:00:00Z
-  2012-03-18T00:00:00Z
-  18 March 2012
-  18 March 2012 at midnight
-  2011 years 6 months 28 days
-  Two Thousand Twelve
-  March, Two Thousand Twelve
-   2012-03-18Z
-   2012-03-18Z
-  
-    Non matching lexical value with language.
-  
-  
-    @value overrides @content in the 'data' element.
-  
-  18 March 2012 at midnight in San Francisco
-  
-  @href becomes subject when @property and @content are present
-  ignored
-  @href becomes subject when @property and @datatype are present
-  value
-  @href as subject overridden by @about
-  ignored
-  @about overriding @href as subject is used as parent resource
-  
-    value two
-  
-  Testing the ':' character usage in a CURIE
-  
-     Test
-  
-  None of these triples should be generated in RDFa 1.0.
-  
-    Vocabulary Prefixes
-    GRDDL
-    MA
-    OWL
-    RDF
-    RDFa
-    RDFS
-    RIF
-    SKOS
-    SKOS-XL
-    WDR
-    VOID
-    WDRS
-    XHV
-    XML
-    XSD
-  
-  
-    Widely Used prefixes
-    CC
-    CTAG
-    DC
-    DCTERMS
-    FOAF
-    GR
-    ICAL
-    OG
-    REV
-    SIOC
-    V
-    VCARD
-    Schema
-  
-  
-    Vocabulary Terms
-    DescribedBy
-  
-
-""",
-     "rdfagraph";
+<http://rdfa.info/test-suite/test-cases/rdfa1.1/xhtml1/0295.xhtml>
+   dct:title "rdfagraph";
    ctag: "CTAG";
    cc: "CC";
    cc:attributionURL <http://rdfa.info/>;
@@ -652,13 +261,12 @@ an XMLLiteral
    og: "OG";
    dct: "DC",
      "DCTERMS";
-   dct:contributor "Mark Birbeck",
-     "Shane McCarron";
+   dct:contributor "Mark Birbeck";
    dct:language "Ruby";
    gr: "GR";
    rev: "REV";
    rdfatest:cornerCase1 <http://rdfa.info/test-suite/test-cases/rdfa1.1/xhtml1/>;
-   rdfatest:cornerCase2 <http://example.org/foo/..>;
+   rdfatest:cornerCase2 <http://example.org/>;
    rdfatest:cornerCase3 <http://rdfa.info/test-suite/test-cases/rdfa1.1/xhtml1/...>;
    rdfatest:cornerCase4 <http://rdfa.info/test-suite/test-cases/rdfa1.1/xhtml1/0295.xhtml?foo=bar../baz>;
    rdfatest:cornerCase5 <http://rdfa.info/test-suite/test-cases/.../.htaccess>;
@@ -674,21 +282,17 @@ an XMLLiteral
      "2012-03-18T00:00:00Z"^^xsd:dateTime,
      " 2012-03-18Z"^^xsd:dateTime,
      "2012-03-18T00:00:00-08:00"^^xsd:dateTime,
-     "veni, vidi, vici",
      "2012-03-18T00:00:00Z"^^xsd:date,
      " 2012-03-18Z",
      "2012-03-18Z"^^xsd:date,
      "D-Day"@en,
+	 "I came, I saw, I conquered"@lat,
      "";
    xhv: "XHV";
    xhv:index <http://rdfa.info/test-suite/#>;
-   xhv:license xmlzzz:license,
-     <http://creativecommons.org/licenses/by-nc-sa/2.0/>,
-     "License",
-     "license";
+   xhv:license "License", "license";
    xhv:next <http://rdfa.info/test-suite/test-cases/rdfa1.1/xhtml1/0115.xhtml>;
-   xhv:role "Role",
-     xmlzzz:role;
+   xhv:role "Role";
    xhv:up <http://rdfa.info/test-suite/test-cases/rdfa1.1/xhtml1/>;
    rdfs: "RDFS";
    xsd: "XSD";
@@ -714,7 +318,31 @@ an XMLLiteral
      a :Person;
      :name "John Doe"
    ],
-     <http://www.example.org/#me> .
+     <http://www.example.org/#me> ;
+   xhv:alternate "alternate" ;
+   xhv:appendix "appendix" ;
+   xhv:cite "cite" ;
+   xhv:bookmark "bookmark" ;
+   xhv:contents "contents" ;
+   xhv:chapter "chapter" ;
+   xhv:copyright "copyright" ;
+   xhv:first "first" ;
+   xhv:glossary "glossary" ;
+   xhv:help "help" ;
+   xhv:icon "icon" ;
+   xhv:index "index" ;
+   xhv:last "last" ;
+   xhv:meta "meta" ;
+   xhv:next "next" ;
+   xhv:prev "prev" ;
+   xhv:previous "previous" ;
+   xhv:section "section" ;
+   xhv:start "start" ;
+   xhv:stylesheet "stylesheet" ;
+   xhv:subsection "subsection" ;
+   xhv:top "top" ;
+   xhv:up "up" ;
+   xhv:p3pv1 "p3pv1" .
 
 <http://www.example.org/#fabien> :name "Fabien Gandon" .
 

--- a/test-suite/test-cases/rdfa1.1/xhtml1/0295.xhtml
+++ b/test-suite/test-cases/rdfa1.1/xhtml1/0295.xhtml
@@ -451,11 +451,11 @@ resource="[_:b]">knows</span>
          <p about="">This is <span property="dc:title">Test 0109</span>.</p>
       </div>
     <div rel="xhv:next">
-      <div rel="xhv:next" />
+      <img rel="xhv:next" />
     </div>
     <div rel="xhv:next">
       <div rel="xhv:next">
-        <div rel="xhv:next" />
+        <img rel="xhv:next" />
       </div>
     </div>
   	  <p>
@@ -507,14 +507,14 @@ whitespace     preserved
 	         is the default prefix for XHTML+RDFa 1.0.
 	      </p>
     <div>
-	<p about="http://example.org/">
+	<div about="http://example.org/">
 		<span about="[]" property="dc:title">Test Case 0121</span>
 		checks to make sure RDFa processors resolve the empty CURIE correctly.
 		<p resource="[]">
 			<span property="dc:contributor">Shane McCarron</span>
 			contributed to this test.
 		</p>
-	</p>
+	</div>
 	</div>
     <p about="http://example.org/section1.html">
          This section is contained below <span rel="up" resource="[]">the main site</span>.
@@ -843,7 +843,7 @@ an XMLLiteral</p>
     Non matching lexical value with language.
   </time>
   <data property="rdf:value" lang="lat" value="veni, vidi, vici" content="I came, I saw, I conquered">
-    @value overrides @content in the 'data' element.
+    @value does not override @content in the 'data' element.
   </data>
   <time property="rdf:value" datetime="2012-03-18T00:00:00-08:00">18 March 2012 at midnight in San Francisco</time>
   <object property="rdf:value" data="http://example.com/"></object>

--- a/test-suite/test-cases/rdfa1.1/xhtml5-invalid/0295.xhtml
+++ b/test-suite/test-cases/rdfa1.1/xhtml5-invalid/0295.xhtml
@@ -451,11 +451,11 @@ resource="[_:b]">knows</span>
          <p about="">This is <span property="dc:title">Test 0109</span>.</p>
       </div>
     <div rel="xhv:next">
-      <div rel="xhv:next" />
+      <img rel="xhv:next" />
     </div>
     <div rel="xhv:next">
       <div rel="xhv:next">
-        <div rel="xhv:next" />
+        <img rel="xhv:next" />
       </div>
     </div>
   	  <p>
@@ -507,14 +507,14 @@ whitespace     preserved
 	         is the default prefix for XHTML+RDFa 1.0.
 	      </p>
     <div>
-	<p about="http://example.org/">
+	<div about="http://example.org/">
 		<span about="[]" property="dc:title">Test Case 0121</span>
 		checks to make sure RDFa processors resolve the empty CURIE correctly.
 		<p resource="[]">
 			<span property="dc:contributor">Shane McCarron</span>
 			contributed to this test.
 		</p>
-	</p>
+	</div>
 	</div>
     <p about="http://example.org/section1.html">
          This section is contained below <span rel="up" resource="[]">the main site</span>.
@@ -843,7 +843,7 @@ an XMLLiteral</p>
     Non matching lexical value with language.
   </time>
   <data property="rdf:value" lang="lat" value="veni, vidi, vici" content="I came, I saw, I conquered">
-    @value overrides @content in the 'data' element.
+    @value does not override @content in the 'data' element.
   </data>
   <time property="rdf:value" datetime="2012-03-18T00:00:00-08:00">18 March 2012 at midnight in San Francisco</time>
   <object property="rdf:value" data="http://example.com/"></object>

--- a/test-suite/test-cases/rdfa1.1/xhtml5/0121.xhtml
+++ b/test-suite/test-cases/rdfa1.1/xhtml5/0121.xhtml
@@ -6,14 +6,14 @@
    </head>
    <body>
     <div>
-	<p about="http://example.org/">
+	<div about="http://example.org/">
 		<span about="[]" property="dc:title">Test Case 0121</span>
 		checks to make sure RDFa processors resolve the empty CURIE correctly.
 		<p resource="[]">
 			<span property="dc:contributor">Shane McCarron</span>
 			contributed to this test.
 		</p>
-	</p>
+	</div>
 	</div>
    </body>
 

--- a/test-suite/test-cases/rdfa1.1/xhtml5/0198.ttl
+++ b/test-suite/test-cases/rdfa1.1/xhtml5/0198.ttl
@@ -4,5 +4,5 @@
 
 <http://www.example.org/me#mark> a foaf:Person;
    foaf:firstName "Mark";
-   foaf:name "<span property=\"foaf:firstName\">Mark</span> <span property=\"foaf:surname\">Birbeck</span><span xmlns=\"http://www.w3.org/1999/xhtml\" property=\"foaf:firstName\">Mark</span><span xmlns=\"http://www.w3.org/1999/xhtml\" property=\"foaf:surname\">Birbeck</span>"^^rdf:XMLLiteral;
+   foaf:name "<span property=\"foaf:firstName\" xmlns=\"http://www.w3.org/1999/xhtml\" xmlns:foaf=\"http://xmlns.com/foaf/0.1/\" xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\">Mark</span> <span property=\"foaf:surname\" xmlns=\"http://www.w3.org/1999/xhtml\" xmlns:foaf=\"http://xmlns.com/foaf/0.1/\" xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\">Birbeck</span>"^^rdf:XMLLiteral;
    foaf:surname "Birbeck" .

--- a/test-suite/test-cases/rdfa1.1/xhtml5/0279.sparql
+++ b/test-suite/test-cases/rdfa1.1/xhtml5/0279.sparql
@@ -2,5 +2,5 @@ PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 ASK WHERE {
-  [ rdf:value "2012-03-18T00:00:00Z"^^xsd:date ] .
+  <http://rdfa.info/test-suite/test-cases/rdfa1.1/xhtml5/0279.xhtml> rdf:value "2012-03-18T00:00:00Z"^^xsd:date .
 }

--- a/test-suite/test-cases/rdfa1.1/xhtml5/0279.ttl
+++ b/test-suite/test-cases/rdfa1.1/xhtml5/0279.ttl
@@ -1,4 +1,4 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-[ rdf:value "2012-03-18T00:00:00Z"^^xsd:date ] .
+<http://rdfa.info/test-suite/test-cases/rdfa1.1/xhtml5/0279.xhtml> rdf:value "2012-03-18T00:00:00Z"^^xsd:date .

--- a/test-suite/test-cases/rdfa1.1/xhtml5/0281.sparql
+++ b/test-suite/test-cases/rdfa1.1/xhtml5/0281.sparql
@@ -2,5 +2,5 @@ PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 ASK WHERE {
-  [ rdf:value "2012"^^xsd:gYear ] .
+  <http://rdfa.info/test-suite/test-cases/rdfa1.1/xhtml5/0281.xhtml> rdf:value "2012"^^xsd:gYear .
 }

--- a/test-suite/test-cases/rdfa1.1/xhtml5/0281.ttl
+++ b/test-suite/test-cases/rdfa1.1/xhtml5/0281.ttl
@@ -1,4 +1,4 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-[ rdf:value "2012"^^xsd:gYear ] .
+<http://rdfa.info/test-suite/test-cases/rdfa1.1/xhtml5/0281.xhtml> rdf:value "2012"^^xsd:gYear .

--- a/test-suite/test-cases/rdfa1.1/xhtml5/0282.sparql
+++ b/test-suite/test-cases/rdfa1.1/xhtml5/0282.sparql
@@ -2,5 +2,5 @@ PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 ASK WHERE {
-  [ rdf:value "2012-03"^^xsd:gYearMonth ] .
+  <http://rdfa.info/test-suite/test-cases/rdfa1.1/xhtml5/0282.xhtml> rdf:value "2012-03"^^xsd:gYearMonth .
 }

--- a/test-suite/test-cases/rdfa1.1/xhtml5/0282.ttl
+++ b/test-suite/test-cases/rdfa1.1/xhtml5/0282.ttl
@@ -1,4 +1,4 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-[ rdf:value "2012-03"^^xsd:gYearMonth ] .
+<http://rdfa.info/test-suite/test-cases/rdfa1.1/xhtml5/0282.xhtml> rdf:value "2012-03"^^xsd:gYearMonth .

--- a/test-suite/test-cases/rdfa1.1/xhtml5/0284.sparql
+++ b/test-suite/test-cases/rdfa1.1/xhtml5/0284.sparql
@@ -2,5 +2,5 @@ PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 ASK WHERE {
-  [ rdf:value " 2012-03-18"^^xsd:dateTime ] .
+  <http://rdfa.info/test-suite/test-cases/rdfa1.1/xhtml5/0284.xhtml> rdf:value " 2012-03-18"^^xsd:dateTime .
 }

--- a/test-suite/test-cases/rdfa1.1/xhtml5/0284.ttl
+++ b/test-suite/test-cases/rdfa1.1/xhtml5/0284.ttl
@@ -1,4 +1,4 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-[ rdf:value " 2012-03-18"^^xsd:dateTime ] .
+<http://rdfa.info/test-suite/test-cases/rdfa1.1/xhtml5/0284.xhtml> rdf:value " 2012-03-18"^^xsd:dateTime .

--- a/test-suite/test-cases/rdfa1.1/xhtml5/0325.sparql
+++ b/test-suite/test-cases/rdfa1.1/xhtml5/0325.sparql
@@ -1,7 +1,7 @@
 BASE <http://example.org/>
 PREFIX schema: <http://schema.org/>
 ASK WHERE {
-  #foo schema:refers-to _:p .
-  #bar schema:refers-to _:p .
+  <#foo> schema:refers-to _:p .
+  <#bar> schema:refers-to _:p .
   _:p schema:name "Amanda" .
 }

--- a/test-suite/test-cases/rdfa1.1/xml/0121.xml
+++ b/test-suite/test-cases/rdfa1.1/xml/0121.xml
@@ -5,14 +5,14 @@
    </head>
    <body>
     <div>
-	<p about="http://example.org/">
+	<div about="http://example.org/">
 		<span about="[]" property="dc:title">Test Case 0121</span>
 		checks to make sure RDFa processors resolve the empty CURIE correctly.
 		<p resource="[]">
 			<span property="dc:contributor">Shane McCarron</span>
 			contributed to this test.
 		</p>
-	</p>
+	</div>
 	</div>
    </body>
 

--- a/test-suite/test-cases/rdfa1.1/xml/0295.ttl
+++ b/test-suite/test-cases/rdfa1.1/xml/0295.ttl
@@ -35,7 +35,8 @@
 
 xmlzzz: dct:title "Test Case 0121",
      "Example Website";
-   rdf:value "value" .
+   rdf:value "value" ;
+   dct:contributor "Shane McCarron" .
 
 xmlzzz:example.png a :Image;
    xhv:license <http://creativecommons.org/licenses/by-nc-sa/2.0/> .
@@ -92,9 +93,9 @@ xmlzzz:jd vcard:fn "John Doe" .
      <http://creativecommons.org/licenses/by-nd/3.0/>;
    xhv:meta xmlzzz:meta;
    xhv:next <http://rdfa.info/test-suite/test-cases/rdfa1.1/xml/0070.xml>,
-     xmlzzz:next,  [ xhv:next <http://rdfa.info/test-suite/test-cases/rdfa1.1/xml/0295.xml#b>,
-       xmlzzz:node,
-       <http://rdfa.info/test-suite/test-cases/rdfa1.1/xml/0295.xml#a>,  [ xhv:next []]];
+     [ xhv:next [] ],
+     [],
+      xmlzzz:next;
    xhv:p3pv1 xmlzzz:p3pv1;
    xhv:prev xmlzzz:prev,
      <http://rdfa.info/test-suite/test-cases/rdfa1.1/xml/0069.xml>;
@@ -128,7 +129,7 @@ xmlzzz:jd vcard:fn "John Doe" .
 
 <http://rdfa.info/test-suite/test-cases/rdfa1.1/xml/0295.xml#mark> a :Person;
    :firstName "Mark";
-   :name "<span property=\"foaf:firstName\">Mark</span> <span property=\"foaf:surname\">Birbeck</span><span xmlns=\"http://www.w3.org/1999/xhtml\" property=\"foaf:firstName\">Mark</span><span xmlns=\"http://www.w3.org/1999/xhtml\" property=\"foaf:surname\">Birbeck</span>"^^rdf:XMLLiteral;
+   :name "<span property=\"foaf:firstName\" xmlns:air=\"http://www.daml.org/2001/10/html/airport-ont#\" xmlns:bio=\"http://vocab.org/bio/0.1/\" xmlns:cal=\"http://www.w3.org/2002/12/cal/icaltzd#\" xmlns:cc=\"http://creativecommons.org/ns#\" xmlns:cert=\"http://www.w3.org/ns/auth/cert#\" xmlns:contact=\"http://www.w3.org/2000/10/swap/pim/contact#\" xmlns:dc=\"http://purl.org/dc/terms/\" xmlns:dct=\"http://purl.org/dc/terms/\" xmlns:earl=\"http://www.w3.org/ns/earl#\" xmlns:ex=\"http://example.org/\" xmlns:example=\"http://example.org/\" xmlns:foaf=\"http://xmlns.com/foaf/0.1/\" xmlns:google=\"http://rdf.data-vocabulary.org/#\" xmlns:ical=\"http://www.w3.org/2002/12/cal/icaltzd#\" xmlns:openid=\"http://xmlns.openid.net/auth#\" xmlns:owl=\"http://www.w3.org/2002/07/owl#\" xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\" xmlns:rdfatest=\"http://rdfa.info/vocabs/rdfa-test#\" xmlns:rdfs=\"http://www.w3.org/2000/01/rdf-schema#\" xmlns:rel=\"http://vocab.org/relationship/\" xmlns:rsa=\"http://www.w3.org/ns/auth/rsa#\" xmlns:rss=\"http://web.resource.org/rss/1.0/\" xmlns:sioc=\"http://rdfs.org/sioc/ns#\" xmlns:v=\"http://www.w3.org/2006/vcard/ns#\" xmlns:wot=\"http://xmlns.com/wot/0.1/\" xmlns:xhv=\"http://www.w3.org/1999/xhtml/vocab#\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema#\">Mark</span> <span property=\"foaf:surname\" xmlns:air=\"http://www.daml.org/2001/10/html/airport-ont#\" xmlns:bio=\"http://vocab.org/bio/0.1/\" xmlns:cal=\"http://www.w3.org/2002/12/cal/icaltzd#\" xmlns:cc=\"http://creativecommons.org/ns#\" xmlns:cert=\"http://www.w3.org/ns/auth/cert#\" xmlns:contact=\"http://www.w3.org/2000/10/swap/pim/contact#\" xmlns:dc=\"http://purl.org/dc/terms/\" xmlns:dct=\"http://purl.org/dc/terms/\" xmlns:earl=\"http://www.w3.org/ns/earl#\" xmlns:ex=\"http://example.org/\" xmlns:example=\"http://example.org/\" xmlns:foaf=\"http://xmlns.com/foaf/0.1/\" xmlns:google=\"http://rdf.data-vocabulary.org/#\" xmlns:ical=\"http://www.w3.org/2002/12/cal/icaltzd#\" xmlns:openid=\"http://xmlns.openid.net/auth#\" xmlns:owl=\"http://www.w3.org/2002/07/owl#\" xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\" xmlns:rdfatest=\"http://rdfa.info/vocabs/rdfa-test#\" xmlns:rdfs=\"http://www.w3.org/2000/01/rdf-schema#\" xmlns:rel=\"http://vocab.org/relationship/\" xmlns:rsa=\"http://www.w3.org/ns/auth/rsa#\" xmlns:rss=\"http://web.resource.org/rss/1.0/\" xmlns:sioc=\"http://rdfs.org/sioc/ns#\" xmlns:v=\"http://www.w3.org/2006/vcard/ns#\" xmlns:wot=\"http://xmlns.com/wot/0.1/\" xmlns:xhv=\"http://www.w3.org/1999/xhtml/vocab#\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema#\">Birbeck</span>"^^rdf:XMLLiteral;
    :surname "Birbeck" .
 
 <http://rdfa.info/test-suite/test-cases/rdfa1.1/xml/0295.xml#this> a dct:Agent;
@@ -198,7 +199,7 @@ whitespace     preserved
 
 <http://rdfa.info/test-suite/test-cases/rdfa1.1/xml/res> rdf:value ("Bar"),  ("Bar") .
 
-<http://sw-app.org/img/mic_2006_03.jpg> xhv:alternate <http://rdfa.info/test-suite/test-cases/rdfa1.1/xml/0295.xml#b>;
+<http://sw-app.org/img/mic_2006_03.jpg> xhv:alternate <http://rdfa.info/test-suite/test-cases/rdfa1.1/xml/0295.xml>;
    :depicts <http://sw-app.org/mic.xhtml#i> .
 
 <http://sw-app.org/mic.xhtml#photo> :depicts <http://sw-app.org/mic.xhtml#i> .
@@ -221,425 +222,10 @@ whitespace     preserved
    :knows <http://www.example.org/#somebody>;
    :name "Dan Brickley" .
 
-<http://rdfa.info/test-suite/test-cases/rdfa1.1/xml/0295.xml#b> dct:title """
-    
-      Test Suite
-      Test Case 0115
-      Test Case 0114
-      RDFa Website
-      Corner Case #1
-      Corner Case #2
-      Corner Case #3
-      Corner Case #4
-      Corner Case #5
-    
-      Description: XML entities in the RDFa content
-      
-        >
-        Ben & Co.
-        @
-        @
-      
-      
-		Mark Birbeck
-         added this triple test.
-      
-      
-         Check to see if parsers get confused when "" is
-         interpreted as NULL in some chaining cases.
-         Ben
-      
-      
-         
-            The
-            Example Website
-            is used in many W3C tutorials.
-         
-      
-      
-	         The
-	         The XHTML Vocabulary Document
-	         is the default prefix for XHTML+RDFa 1.0.
-	      
-    
-	
-		Test Case 0121
-		checks to make sure RDFa processors resolve the empty CURIE correctly.
-		
-			Shane McCarron
-			contributed to this test.
-		
-	
-	
-    
-         This section is contained below the main site.
-      
-      
-        My article
-      
-Blank Nodes are not allowed to be predicate identifiers in RDF:
-Test
-Test
-   
-      This test ensures that single-character prefixes are allowed. 
-      My name is:
-      John Doe 
-   
-    My name is
-      Gregg Kellogg.
-    
-    
-      Manu can be reached via
-      email.
-      He knows Gregg.
-      Who knows Manu.
-    
+<http://rdfa.info/test-suite/test-cases/rdfa1.1/xml/0295.xml#b> dct:title "".
 
-    
-      Gregg can be reached via
-      email.
-    
-    
-        Ivan Herman
-    
-    
-        A particular agent
-    
-    
-  
-      Ivan Herman
-  
-  
-      Ivan Herman
-  
-  
-      Ivan Herman
-  
-    
-      
-        A particular agent
-      
-    
-  
-    
-      A particular agent
-    
-  
-  
-    Ivan Herman
-  
-    
-      
-        Ivan Herman
-      
-    
-    
-      
-        Ivan Herman
-      
-    
-    
-      Ivan Herman
-    
-    
-      Ivan Herman
-    
-	
-    This is an XMLLiteral
-    This is a plain literal
-
-  Gregg Kellogg
-  Ruby
-  Kellogg Associates
-  Ruby Gem
-      
-        Mark Birbeck
-      
-	
-	    An OWL Axiom: "xsd:maxExclusive" is a Datatype Property in OWL.
-	
-   
-       Weekend off in Iona: 
-       Oct 21st
-       to Oct 23rd.
-       See FreeTime.Example.org for
-       info on Iona, UK.
-   
-    
-    
-        Ivan Herman
-    
-    
-  
-      Ivan Herman
-  
-    
-  
-      Ivan Herman
-  
-	  
-  	
-      E = mc2: The Most Urgent Problem of Our Time
-	
-    
-  	
-      E = mc2: The Most Urgent Problem of Our Time
-	
-   This document has a title.
-      
-	  Iván
-      
-	  Iván
-  
-    Gregg Kellogg
-  
-  
-    
-  
-  
-    Foo
-  
-  
-    Foo
-  
-  
-    Foo
-    Foo
-  
-  
-    Foo
-    Bar
-  
-  
-    Foo
-    Bar
-    Baz
-  
-  
-    
-      Foo
-      Bar
-    
-  
-  
-    Foo
-  
-  
-    Bar
-  
-  
-    Foo
-    
-      Bar
-    
-  
-  
-    Foo
-    
-      Bar
-    
-  
-  	
-     	
-  	
-  	
-  	  
-  	
-  
-    
-  
-  
-    
-  
-  	
-	    John Doe
-   	
-  	
-	    John Doe
-   	
-      
-         describedby
-         license
-         role
-      
-    
-      The rdfagraph should not generate triples when
-      looking only at the processor graph.
-    
-  	
-  	
-    ελληνικό
-άσπρο   διάστημα
-
-  	
-    
-Ensure that the "_" prefix is ignored.
-Test
-  
-    Vocabulary Prefixes
-    GRDDL
-    MA
-    OWL
-    RDF
-    RDFa
-    RDFS
-    RIF
-    SKOS
-    SKOS-XL
-    WDR
-    VOID
-    WDRS
-    XHV
-    XML
-    XSD
-  
-  
-    Widely Used prefixes
-    CC
-    CTAG
-    DC
-    DCTERMS
-    FOAF
-    GR
-    ICAL
-    OG
-    REV
-    SIOC
-    V
-    VCARD
-    Schema
-  
-  
-    Vocabulary Terms
-    DescribedBy
-    License
-    Role
-  
-  
-    Vocabulary Terms
-    alternate
-    appendix
-    cite
-    bookmark
-    contents
-    chapter
-    copyright
-    first
-    glossary
-    help
-    icon
-    index
-    last
-    license
-    meta
-    next
-    prev
-    previous
-    section
-    start
-    stylesheet
-    subsection
-    top
-    up
-    p3pv1
-  
-	
-    This is
-an XMLLiteral
-
-   This photo was taken by Mark Birbeck.
-   
-   
-   
-  
-     Ivan Herman
-  
-  
-     Ivan Herman
-  
-  
-     
-  
-   
-   
-   
-  18 March 2012
-  midnight
-  18 March 2012 at midnight
-  2012-03-18Z
-  00:00:00Z
-  2012-03-18T00:00:00Z
-  18 March 2012
-  18 March 2012 at midnight
-  2011 years 6 months 28 days
-  Two Thousand Twelve
-  March, Two Thousand Twelve
-   2012-03-18Z
-   2012-03-18Z
-  
-    Non matching lexical value with language.
-  
-  
-    @value overrides @content in the 'data' element.
-  
-  18 March 2012 at midnight in San Francisco
-  
-  @href becomes subject when @property and @content are present
-  ignored
-  @href becomes subject when @property and @datatype are present
-  value
-  @href as subject overridden by @about
-  ignored
-  @about overriding @href as subject is used as parent resource
-  
-    value two
-  
-  Testing the ':' character usage in a CURIE
-  
-     Test
-  
-  None of these triples should be generated in RDFa 1.0.
-  
-    Vocabulary Prefixes
-    GRDDL
-    MA
-    OWL
-    RDF
-    RDFa
-    RDFS
-    RIF
-    SKOS
-    SKOS-XL
-    WDR
-    VOID
-    WDRS
-    XHV
-    XML
-    XSD
-  
-  
-    Widely Used prefixes
-    CC
-    CTAG
-    DC
-    DCTERMS
-    FOAF
-    GR
-    ICAL
-    OG
-    REV
-    SIOC
-    V
-    VCARD
-    Schema
-  
-  
-    Vocabulary Terms
-    DescribedBy
-  
-
-""",
-     "rdfagraph";
+<http://rdfa.info/test-suite/test-cases/rdfa1.1/xml/0295.xml>
+   dct:title "rdfagraph";
    ctag: "CTAG";
    cc: "CC";
    cc:attributionURL <http://rdfa.info/>;
@@ -651,13 +237,12 @@ an XMLLiteral
    og: "OG";
    dct: "DC",
      "DCTERMS";
-   dct:contributor "Mark Birbeck",
-     "Shane McCarron";
+   dct:contributor "Mark Birbeck";
    dct:language "Ruby";
    gr: "GR";
    rev: "REV";
    rdfatest:cornerCase1 <http://rdfa.info/test-suite/test-cases/rdfa1.1/xml/>;
-   rdfatest:cornerCase2 <http://example.org/foo/..>;
+   rdfatest:cornerCase2 <http://example.org/>;
    rdfatest:cornerCase3 <http://rdfa.info/test-suite/test-cases/rdfa1.1/xml/...>;
    rdfatest:cornerCase4 <http://rdfa.info/test-suite/test-cases/rdfa1.1/xml/0295.xml?foo=bar../baz>;
    rdfatest:cornerCase5 <http://rdfa.info/test-suite/test-cases/.../.htaccess>;
@@ -673,11 +258,11 @@ an XMLLiteral
      "2012-03-18T00:00:00Z"^^xsd:dateTime,
      " 2012-03-18Z"^^xsd:dateTime,
      "2012-03-18T00:00:00-08:00"^^xsd:dateTime,
-     "veni, vidi, vici",
      "2012-03-18T00:00:00Z"^^xsd:date,
      " 2012-03-18Z",
      "2012-03-18Z"^^xsd:date,
      "D-Day"@en,
+	 "I came, I saw, I conquered"@lat,
      "";
    xhv: "XHV";
    xhv:index <http://rdfa.info/test-suite/#>;

--- a/test-suite/test-cases/rdfa1.1/xml/0295.xml
+++ b/test-suite/test-cases/rdfa1.1/xml/0295.xml
@@ -450,11 +450,11 @@ resource="[_:b]">knows</span>
          <p about="">This is <span property="dc:title">Test 0109</span>.</p>
       </div>
     <div rel="xhv:next">
-      <div rel="xhv:next" />
+      <img rel="xhv:next" />
     </div>
     <div rel="xhv:next">
       <div rel="xhv:next">
-        <div rel="xhv:next" />
+        <img rel="xhv:next" />
       </div>
     </div>
   	  <p>
@@ -506,14 +506,14 @@ whitespace     preserved
 	         is the default prefix for XHTML+RDFa 1.0.
 	      </p>
     <div>
-	<p about="http://example.org/">
+	<div about="http://example.org/">
 		<span about="[]" property="dc:title">Test Case 0121</span>
 		checks to make sure RDFa processors resolve the empty CURIE correctly.
 		<p resource="[]">
 			<span property="dc:contributor">Shane McCarron</span>
 			contributed to this test.
 		</p>
-	</p>
+	</div>
 	</div>
     <p about="http://example.org/section1.html">
          This section is contained below <span rel="up" resource="[]">the main site</span>.
@@ -842,7 +842,7 @@ an XMLLiteral</p>
     Non matching lexical value with language.
   </time>
   <data property="rdf:value" lang="lat" value="veni, vidi, vici" content="I came, I saw, I conquered">
-    @value overrides @content in the 'data' element.
+    @value does not override @content in the 'data' element.
   </data>
   <time property="rdf:value" datetime="2012-03-18T00:00:00-08:00">18 March 2012 at midnight in San Francisco</time>
   <object property="rdf:value" data="http://example.com/"></object>


### PR DESCRIPTION
I've noticed a couple of errors in the test suite (or at least, I _think_ they are wrong).

I've updated the following tests:

* 0279, 0281, 0282, 0284: These tests used to expect a blank node subject. However, since the <time> tag appears as a direct child of the <body>, they should have the baseIRI as subject.
* 0325: The input document contains typeof="" attributes. Since the vocab has been explicitly defined, the typeof triples should be created using that vocab.
* 0121: Setting resource to [] should set subject for children to document IRI.
* 0304: The test expected dc:title to be defined using RDF/XML.
However, RDFa parsers are not expected to handle RDF/XML.
* 0198: The expected value contained attributes that were not present
in the input document. Also, for some reason, the expected tags were present twice.
* 0260: These tests used to expect a blank node subject. However, since the tags appears as a child of the <body>, they should have the baseIRI as subject.
* 0295: This was a huge document that contain a lot of errors. I manually went through all the differences with my RDFa parser. Most errors were caused by self-closing tags.