### PR TITLE
Add rdfa-streaming-parser.js to list of tools

### DIFF
--- a/dev.html
+++ b/dev.html
@@ -12,7 +12,11 @@ nav_index: 4
         <dd>
           <dl>
             <dt>JavaScript</dt>
-            <dd><a href="http://code.google.com/p/green-turtle/">Green Turtle</a> is a RDFa 1.1 implementation written in pure JavaScript that runs in the browser.</dd>
+            <dd>
+              <a href="http://code.google.com/p/green-turtle/">Green Turtle</a> is a RDFa 1.1 implementation written in pure JavaScript that runs in the browser.<br />
+              <a href="https://github.com/rubensworks/rdfa-streaming-parser.js">rdfa-streaming-parser.js
+</a> is a fast and lightweight streaming RDFa 1.1 parser for Node.js that also runs in the browser.
+            </dd>
             <dt>PHP</dt>
             <dd><a href="http://www.easyrdf.org/">EasyRDF</a> is a PHP library for extracting RDFa and working with RDF, in general. You must use the latest development version if you want the RDFa parser: <a href="https://github.com/njh/easyrdf/releases">download the latest 0.8 snapshot</a>.</dd>
             <dt>Python</dt>


### PR DESCRIPTION
This PR adds [rdfa-streaming-parser.js](https://github.com/rubensworks/rdfa-streaming-parser.js) to the list of tools.

I also have EARL reports available for this that were generated by running the test suite locally.
I did not use the Web-based test suite runner, as there seem to be problems with it (https://github.com/rdfa/rdfa.github.io/issues/16).
So I was wondering if I can submit my own EARL reports via a (separate) PR as well?